### PR TITLE
Add simple font toggle in settings

### DIFF
--- a/Hibi/ContentView.swift
+++ b/Hibi/ContentView.swift
@@ -17,6 +17,7 @@ struct ContentView: View {
     @State private var editorMode: EventEditorSheet.Mode?
     @Environment(\.scenePhase) private var scenePhase
     @AppStorage("appearance") private var appearanceRaw: String = SettingsView.Appearance.system.rawValue
+    @AppStorage("useSimpleFont") private var useSimpleFont: Bool = false
 
     private var selectionBinding: Binding<CalendarTab> {
         Binding(
@@ -92,7 +93,7 @@ struct ContentView: View {
                 }
                 ToolbarItem(placement: .principal) {
                     Text("\(MonthNames.full[displayedMonth - 1]) · \(String(displayedYear))")
-                        .font(.custom(AppFont.serifItalic, size: 15))
+                        .font(.appSerif(size: 15, italic: true, simple: useSimpleFont))
                         .foregroundStyle(.secondary)
                 }
                 ToolbarItem(placement: .topBarTrailing) {

--- a/Hibi/Models/SampleData.swift
+++ b/Hibi/Models/SampleData.swift
@@ -88,3 +88,15 @@ enum AppFont {
     static let serifRegular = "InstrumentSerif-Regular"
     static let serifItalic  = "InstrumentSerif-Italic"
 }
+
+extension Font {
+    /// App display font. `simple` swaps Instrument Serif for the system
+    /// sans-serif face (driven by the "useSimpleFont" AppStorage toggle).
+    static func appSerif(size: CGFloat, italic: Bool = false, simple: Bool) -> Font {
+        if simple {
+            let base = Font.system(size: size)
+            return italic ? base.italic() : base
+        }
+        return .custom(italic ? AppFont.serifItalic : AppFont.serifRegular, size: size)
+    }
+}

--- a/Hibi/Views/DayView.swift
+++ b/Hibi/Views/DayView.swift
@@ -11,6 +11,7 @@ struct DayView: View {
     @Environment(EventStore.self) private var eventStore
     @Environment(WeatherStore.self) private var weatherStore
     @Environment(\.colorScheme) private var colorScheme
+    @AppStorage("useSimpleFont") private var useSimpleFont: Bool = false
     @State private var dragY: CGFloat = 0
     @State private var isTearing: Bool = false
     @State private var cardShiftAmount: CGFloat = 0
@@ -113,7 +114,7 @@ struct DayView: View {
                 .contentTransition(.numericText(value: Double(day)))
             Spacer()
             Text("est. MMXXVI")
-                .font(.custom(AppFont.serifItalic, size: 13))
+                .font(.appSerif(size: 13, italic: true, simple: useSimpleFont))
                 .foregroundStyle(.secondary)
         }
         .padding(.horizontal, 20)
@@ -296,7 +297,7 @@ struct DayView: View {
                 }
             } else if events.isEmpty {
                 Text("An open day.")
-                    .font(.custom(AppFont.serifItalic, size: 20))
+                    .font(.appSerif(size: 20, italic: true, simple: useSimpleFont))
                     .foregroundStyle(.secondary)
                     .frame(maxWidth: .infinity)
                     .padding(.vertical, 40)
@@ -463,6 +464,8 @@ private struct PageContent: View {
     let locationName: String?
     let preview: Bool
 
+    @AppStorage("useSimpleFont") private var useSimpleFont: Bool = false
+
     private static let sunFormatter: DateFormatter = {
         let f = DateFormatter()
         f.locale = Locale(identifier: "de_DE")
@@ -497,7 +500,7 @@ private struct PageContent: View {
             .opacity(weather?.sunrise == nil ? 0 : 1)
             Spacer()
             Text(DayNames.full[SampleData.weekday(year: year, month: month, day: day)])
-                .font(.custom(AppFont.serifItalic, size: 19))
+                .font(.appSerif(size: 19, italic: true, simple: useSimpleFont))
                 .foregroundStyle(.primary)
                 .padding(.top, 2)
             Spacer()
@@ -518,7 +521,7 @@ private struct PageContent: View {
     private var numeralBlock: some View {
         VStack(spacing: 2) {
             Text("\(day)")
-                .font(.custom(AppFont.serifRegular, size: 180))
+                .font(.appSerif(size: 180, simple: useSimpleFont))
                 .foregroundStyle(.primary)
                 .lineLimit(1)
                 .minimumScaleFactor(0.5)

--- a/Hibi/Views/MonthView.swift
+++ b/Hibi/Views/MonthView.swift
@@ -6,6 +6,7 @@ struct MonthView: View {
     var onPickDay: (Int) -> Void
 
     @Environment(EventStore.self) private var eventStore
+    @AppStorage("useSimpleFont") private var useSimpleFont: Bool = false
 
     var body: some View {
         let totalDays = SampleData.daysInMonth(year: year, month: month)
@@ -29,12 +30,12 @@ struct MonthView: View {
     private func header(weekCount: Int) -> some View {
         VStack(alignment: .leading, spacing: -4) {
             Text(String(year))
-                .font(.custom(AppFont.serifItalic, size: 15))
+                .font(.appSerif(size: 15, italic: true, simple: useSimpleFont))
                 .tracking(0.4)
                 .foregroundStyle(.secondary)
             HStack(alignment: .lastTextBaseline) {
                 Text(MonthNames.full[month - 1])
-                    .font(.custom(AppFont.serifRegular, size: 72))
+                    .font(.appSerif(size: 72, simple: useSimpleFont))
                     .tracking(-1.5)
                     .foregroundStyle(.primary)
                 Spacer()
@@ -89,6 +90,7 @@ private struct DayCell: View {
     let day: Int
 
     @Environment(EventStore.self) private var eventStore
+    @AppStorage("useSimpleFont") private var useSimpleFont: Bool = false
 
     var body: some View {
         let events = eventStore.events(year: year, month: month, day: day)
@@ -97,7 +99,7 @@ private struct DayCell: View {
         ZStack(alignment: .top) {
             VStack(spacing: 4) {
                 Text("\(day)")
-                    .font(.custom(AppFont.serifRegular, size: 22))
+                    .font(.appSerif(size: 22, simple: useSimpleFont))
                     .tracking(-0.2)
                     .foregroundStyle(.primary)
                     .frame(width: 32, height: 32)

--- a/Hibi/Views/SettingsView.swift
+++ b/Hibi/Views/SettingsView.swift
@@ -5,6 +5,7 @@ struct SettingsView: View {
     @Environment(\.dismiss) private var dismiss
     @Environment(EventStore.self) private var eventStore
     @AppStorage("appearance") private var appearanceRaw: String = Appearance.system.rawValue
+    @AppStorage("useSimpleFont") private var useSimpleFont: Bool = false
 
     enum Appearance: String, CaseIterable, Identifiable {
         case system, light, dark
@@ -28,6 +29,8 @@ struct SettingsView: View {
                         }
                     }
                     .pickerStyle(.segmented)
+
+                    Toggle("Simple font", isOn: $useSimpleFont)
                 }
 
                 Section("Calendars") {

--- a/Hibi/Views/StreamView.swift
+++ b/Hibi/Views/StreamView.swift
@@ -213,6 +213,7 @@ private struct StreamDayRow: View {
 
     @Environment(EventStore.self) private var eventStore
     @Environment(WeatherStore.self) private var weatherStore
+    @AppStorage("useSimpleFont") private var useSimpleFont: Bool = false
 
     var body: some View {
         let events = eventStore.events(year: year, month: month, day: day)
@@ -302,7 +303,7 @@ private struct StreamDayRow: View {
                 .padding(.top, 2)
             if day == 1 {
                 Text(MonthNames.short[month - 1])
-                    .font(.custom(AppFont.serifItalic, size: 11))
+                    .font(.appSerif(size: 11, italic: true, simple: useSimpleFont))
                     .foregroundStyle(.secondary)
                     .padding(.top, 6)
             }
@@ -313,7 +314,7 @@ private struct StreamDayRow: View {
 
     private func streamDayNumberText() -> some View {
         Text("\(day)")
-            .font(.custom(AppFont.serifRegular, size: 34))
+            .font(.appSerif(size: 34, simple: useSimpleFont))
             .tracking(-0.5)
             .foregroundStyle(.primary)
     }


### PR DESCRIPTION
Closes #4.

## Summary
- Adds a **Simple font** toggle in Settings → Appearance.
- When on, swaps Instrument Serif for the system sans-serif face across the Month, Week, and Day tabs (plus the toolbar principal title).
- When off (default), the app keeps its current serif look.

## How it's wired
- New `Font.appSerif(size:italic:simple:)` helper in `SampleData.swift` — returns `.custom(InstrumentSerif-…)` or `.system(size:).italic()` based on the flag.
- Every existing `.font(.custom(AppFont.serif…, size:))` call now routes through `.appSerif(...)`.
- Each affected view reads `@AppStorage("useSimpleFont")` so toggling updates instantly.
- `AppFont.serifRegular` / `serifItalic` string constants are kept since `HibiApp.init` still uses them to register the TTFs at launch.

## Notes for reviewer
- The existing serif calls have hand-tuned `.tracking(...)` values (e.g. `-1.5` on the 72pt month name). These stay the same in simple mode — may need eyeballing in SF, but didn't want to guess new values without seeing it.
- Italic in simple mode uses SF's true italic via `Font.system(size:).italic()`.

## Test plan
- [ ] Open Settings, toggle **Simple font** on — all serif text in Month / Week / Day tabs switches to system sans-serif.
- [ ] Toggle off — serif returns.
- [ ] Relaunch with toggle on — preference persists.
- [ ] Verify italic sites (year label, masthead "est. MMXXVI", weekday, "An open day.") render italic in simple mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)