### PR TITLE
Customizable day-view swipe direction (closes #8)

### DIFF
--- a/Hibi/Views/DayView.swift
+++ b/Hibi/Views/DayView.swift
@@ -11,6 +11,7 @@ struct DayView: View {
     @Environment(EventStore.self) private var eventStore
     @Environment(WeatherStore.self) private var weatherStore
     @Environment(\.colorScheme) private var colorScheme
+    @AppStorage("invertDaySwipe") private var invertDaySwipe: Bool = false
     @State private var dragY: CGFloat = 0
     @State private var isTearing: Bool = false
     @State private var cardShiftAmount: CGFloat = 0
@@ -91,7 +92,9 @@ struct DayView: View {
     }
 
     private var pullToTearHint: some View {
-        Text("PULL TO TEAR · ↑ NEXT · ↓ PREV")
+        Text(invertDaySwipe
+             ? "PULL TO TEAR · ↑ PREV · ↓ NEXT"
+             : "PULL TO TEAR · ↑ NEXT · ↓ PREV")
             .font(.system(size: 10))
             .tracking(1.2)
             .foregroundStyle(.secondary.opacity(0.6))
@@ -192,8 +195,10 @@ struct DayView: View {
                             guard !isTearing else { return }
                             dragY = g.translation.height
                             if abs(g.translation.height) > 2 {
-                                // Drag up → next (+1); drag down → prev (-1).
-                                tearDirection = g.translation.height < 0 ? 1 : -1
+                                // Default: drag up → next (+1), drag down → prev (-1).
+                                // Inverted: drag up → prev (-1), drag down → next (+1).
+                                let dragUp = g.translation.height < 0
+                                tearDirection = (dragUp != invertDaySwipe) ? 1 : -1
                             }
                         }
                         .onEnded { _ in handleRelease() }
@@ -362,11 +367,11 @@ struct DayView: View {
 
     private func handleRelease() {
         if dragY < -tearThreshold {
-            // Pull up → next day
-            tear(to: -offScreen, next: true)
+            // Default: pull up → next. Inverted: pull up → previous.
+            tear(to: -offScreen, next: !invertDaySwipe)
         } else if dragY > tearThreshold {
-            // Pull down → previous day
-            tear(to: offScreen, next: false)
+            // Default: pull down → previous. Inverted: pull down → next.
+            tear(to: offScreen, next: invertDaySwipe)
         } else {
             withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) {
                 dragY = 0

--- a/Hibi/Views/SettingsView.swift
+++ b/Hibi/Views/SettingsView.swift
@@ -5,6 +5,7 @@ struct SettingsView: View {
     @Environment(\.dismiss) private var dismiss
     @Environment(EventStore.self) private var eventStore
     @AppStorage("appearance") private var appearanceRaw: String = Appearance.system.rawValue
+    @AppStorage("invertDaySwipe") private var invertDaySwipe: Bool = false
 
     enum Appearance: String, CaseIterable, Identifiable {
         case system, light, dark
@@ -28,6 +29,10 @@ struct SettingsView: View {
                         }
                     }
                     .pickerStyle(.segmented)
+                }
+
+                Section("Day View") {
+                    Toggle("Invert swipe direction", isOn: $invertDaySwipe)
                 }
 
                 Section("Calendars") {


### PR DESCRIPTION
## Summary
- Adds an **Invert swipe direction** toggle to Settings under a new **Day View** section, persisted via `@AppStorage("invertDaySwipe")`.
- `DayView` reads the flag and flips both the drag preview (`tearDirection`) and the release handler (`next:`), so swipe up/down map to prev/next or next/prev based on the setting.
- Updates the on-paper "PULL TO TEAR" hint to reflect the active mapping.
- Default is **off** — existing behavior (swipe up = next, swipe down = prev) is preserved.

Closes #8.

## Test plan
- [ ] Open Settings → Day View → toggle off: swipe up on a day advances to next, swipe down to prev; hint reads `↑ NEXT · ↓ PREV`.
- [ ] Toggle on: swipe up goes to prev, swipe down to next; hint reads `↑ PREV · ↓ NEXT`.
- [ ] Mid-drag preview (card shift + incoming-day events fading in) matches the direction that will commit on release under both settings.
- [ ] Kill/relaunch app — toggle state persists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)