### PR TITLE
Multi-day events across all spanned days + drag-to-move in week view

### DIFF
--- a/Hibi/Models/EventStore.swift
+++ b/Hibi/Models/EventStore.swift
@@ -164,9 +164,21 @@ final class EventStore {
 
         var grouped: [Int: [CalendarEvent]] = [:]
         for ek in raw {
-            let day = calendar.component(.day, from: ek.startDate)
-            let event = makeCalendarEvent(from: ek, day: day)
-            grouped[day, default: []].append(event)
+            // Multi-day events get placed in every day-of-month bucket they overlap
+            // within this month's window. Clamp the event's [startDate, endDate) to
+            // [start, end) so cross-month events only populate the days that belong
+            // to the month we're currently loading.
+            let clampedStart = max(ek.startDate, start)
+            let clampedEnd = min(ek.endDate, end)
+            guard clampedEnd > clampedStart else { continue }
+
+            var cursor = calendar.startOfDay(for: clampedStart)
+            while cursor < clampedEnd {
+                let day = calendar.component(.day, from: cursor)
+                grouped[day, default: []].append(makeCalendarEvent(from: ek, day: day))
+                guard let next = calendar.date(byAdding: .day, value: 1, to: cursor) else { break }
+                cursor = next
+            }
         }
         for d in grouped.keys {
             grouped[d]?.sort { lhs, rhs in
@@ -202,16 +214,110 @@ final class EventStore {
         return ekStore.event(withIdentifier: identifier)
     }
 
+    // MARK: - Mutations (drag & drop)
+
+    /// Move the instance of an event displayed on `from` to land on `to`.
+    ///
+    /// - Single-day events shift entirely by the day delta (duration preserved).
+    /// - Multi-day events adjust a boundary:
+    ///   - Dragging the first-day instance moves `startDate` by the delta.
+    ///   - Dragging the last-day instance moves `endDate` by the delta.
+    ///   - Dragging a middle day moves whichever boundary lies in the drag's direction.
+    ///
+    /// No-ops in demo mode, without full access, for events without identifiers,
+    /// or when source and destination are the same day.
+    @discardableResult
+    func moveEventInstance(
+        identifier: String,
+        from: (year: Int, month: Int, day: Int),
+        to: (year: Int, month: Int, day: Int)
+    ) -> Bool {
+        guard !isDemoMode else { return false }
+        guard authorization == .fullAccess else { return false }
+        guard let ek = ekStore.event(withIdentifier: identifier) else { return false }
+
+        guard
+            let fromMidnight = calendar.date(from: DateComponents(year: from.year, month: from.month, day: from.day)),
+            let toMidnight = calendar.date(from: DateComponents(year: to.year, month: to.month, day: to.day)),
+            let dayDelta = calendar.dateComponents([.day], from: fromMidnight, to: toMidnight).day,
+            dayDelta != 0
+        else { return false }
+
+        // Effective last-day midnight: treat an exact-midnight endDate (EK's
+        // exclusive-end convention for all-day and on-the-minute events) as
+        // belonging to the previous day.
+        let startMidnight = calendar.startOfDay(for: ek.startDate)
+        let endMidnightRaw = calendar.startOfDay(for: ek.endDate)
+        let lastDayMidnight: Date = (ek.endDate == endMidnightRaw)
+            ? (calendar.date(byAdding: .day, value: -1, to: endMidnightRaw) ?? startMidnight)
+            : endMidnightRaw
+        let isSingleDay = startMidnight == lastDayMidnight
+
+        let newStart: Date
+        let newEnd: Date
+        if isSingleDay {
+            guard
+                let s = calendar.date(byAdding: .day, value: dayDelta, to: ek.startDate),
+                let e = calendar.date(byAdding: .day, value: dayDelta, to: ek.endDate)
+            else { return false }
+            newStart = s
+            newEnd = e
+        } else if fromMidnight == startMidnight {
+            // First-day instance dragged: move the start.
+            guard let s = calendar.date(byAdding: .day, value: dayDelta, to: ek.startDate) else { return false }
+            newStart = s
+            newEnd = ek.endDate
+        } else if fromMidnight == lastDayMidnight {
+            // Last-day instance dragged: move the end.
+            guard let e = calendar.date(byAdding: .day, value: dayDelta, to: ek.endDate) else { return false }
+            newStart = ek.startDate
+            newEnd = e
+        } else if dayDelta > 0 {
+            // Middle-day dragged forward: extend end.
+            guard let e = calendar.date(byAdding: .day, value: dayDelta, to: ek.endDate) else { return false }
+            newStart = ek.startDate
+            newEnd = e
+        } else {
+            // Middle-day dragged backward: extend start.
+            guard let s = calendar.date(byAdding: .day, value: dayDelta, to: ek.startDate) else { return false }
+            newStart = s
+            newEnd = ek.endDate
+        }
+
+        guard newEnd > newStart else { return false }
+
+        ek.startDate = newStart
+        ek.endDate = newEnd
+        do {
+            try ekStore.save(ek, span: .thisEvent)
+            // .EKEventStoreChanged fires → reloadAll() refreshes cached months.
+            return true
+        } catch {
+            return false
+        }
+    }
+
     func allLoadedEvents() -> [(year: Int, month: Int, event: CalendarEvent)] {
-        var out: [(Int, Int, CalendarEvent)] = []
+        // Multi-day events appear in every day bucket they span; dedupe by id so
+        // search shows one hit per event. Keep the earliest (year, month, day)
+        // instance so the result's subtitle points to where the event starts.
+        var bestByID: [String: (year: Int, month: Int, event: CalendarEvent)] = [:]
         for (key, days) in eventsByMonth {
             for (_, events) in days {
                 for e in events {
-                    out.append((key.year, key.month, e))
+                    if let existing = bestByID[e.id] {
+                        let isEarlier = (key.year, key.month, e.day) <
+                            (existing.year, existing.month, existing.event.day)
+                        if isEarlier {
+                            bestByID[e.id] = (key.year, key.month, e)
+                        }
+                    } else {
+                        bestByID[e.id] = (key.year, key.month, e)
+                    }
                 }
             }
         }
-        return out
+        return Array(bestByID.values)
     }
 
     // MARK: - Adapters

--- a/Hibi/Views/StreamView.swift
+++ b/Hibi/Views/StreamView.swift
@@ -1,5 +1,20 @@
 import EventKit
 import SwiftUI
+import UniformTypeIdentifiers
+
+/// Transferable payload for long-press drag of an event instance in the week view.
+/// Carries the source day so `EventStore.moveEventInstance(...)` can decide whether
+/// the user grabbed the first, middle, or last day of a multi-day span.
+struct DraggedEvent: Codable, Transferable {
+    let eventIdentifier: String
+    let sourceYear: Int
+    let sourceMonth: Int
+    let sourceDay: Int
+
+    static var transferRepresentation: some TransferRepresentation {
+        CodableRepresentation(contentType: .data)
+    }
+}
 
 struct StreamView: View {
     @Binding var displayedYear: Int
@@ -213,6 +228,7 @@ private struct StreamDayRow: View {
 
     @Environment(EventStore.self) private var eventStore
     @Environment(WeatherStore.self) private var weatherStore
+    @State private var isDropTargeted: Bool = false
 
     var body: some View {
         let events = eventStore.events(year: year, month: month, day: day)
@@ -244,21 +260,7 @@ private struct StreamDayRow: View {
                     // Tick once a minute so the fill advances with the day.
                     TimelineView(.periodic(from: .now, by: 60)) { ctx in
                         ForEach(events) { event in
-                            Button {
-                                onTapEvent(event)
-                            } label: {
-                                EventCard(
-                                    event: event,
-                                    progress: event.progress(
-                                        at: ctx.date,
-                                        useDemoTimeOfDay: eventStore.isDemoMode,
-                                        listYear: year,
-                                        listMonth: month,
-                                        listDay: day
-                                    )
-                                )
-                            }
-                            .buttonStyle(.plain)
+                            eventButton(event: event, now: ctx.date)
                         }
                     }
                 }
@@ -278,8 +280,69 @@ private struct StreamDayRow: View {
                     .frame(height: 0.5)
             }
         }
+        .background {
+            // Subtle highlight while a dragged event hovers this row.
+            if isDropTargeted {
+                RoundedRectangle(cornerRadius: 10)
+                    .fill(Color.primary.opacity(0.06))
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 4)
+                    .transition(.opacity)
+            }
+        }
+        .animation(.easeInOut(duration: 0.12), value: isDropTargeted)
+        .contentShape(Rectangle())
+        .dropDestination(for: DraggedEvent.self) { items, _ in
+            guard let payload = items.first else { return false }
+            guard
+                payload.sourceYear != year ||
+                payload.sourceMonth != month ||
+                payload.sourceDay != day
+            else { return false }
+            return eventStore.moveEventInstance(
+                identifier: payload.eventIdentifier,
+                from: (payload.sourceYear, payload.sourceMonth, payload.sourceDay),
+                to: (year, month, day)
+            )
+        } isTargeted: { targeted in
+            isDropTargeted = targeted
+        }
         .task(id: MonthKey(year: year, month: month)) {
             eventStore.ensureLoaded(year: year, month: month)
+        }
+    }
+
+    @ViewBuilder
+    private func eventButton(event: CalendarEvent, now: Date) -> some View {
+        let card = EventCard(
+            event: event,
+            progress: event.progress(
+                at: now,
+                useDemoTimeOfDay: eventStore.isDemoMode,
+                listYear: year,
+                listMonth: month,
+                listDay: day
+            )
+        )
+        let button = Button {
+            onTapEvent(event)
+        } label: {
+            card
+        }
+        .buttonStyle(.plain)
+
+        if let id = event.eventIdentifier, !eventStore.isDemoMode {
+            button.draggable(DraggedEvent(
+                eventIdentifier: id,
+                sourceYear: year,
+                sourceMonth: month,
+                sourceDay: day
+            )) {
+                // Drag preview — render the card at its own intrinsic size.
+                card.frame(maxWidth: 320)
+            }
+        } else {
+            button
         }
     }
 


### PR DESCRIPTION
## Summary

- **Closes #7**: events that span multiple days now render on every day they cover (month, week, and day views). Cross-month events are clamped to the month being loaded so each month only shows its own days.
- **Closes #9**: long-press an event in the weekly view to drag it onto another day. Moving multi-day events adjusts the appropriate boundary so days in between fill in automatically.

## Implementation notes

### `EventStore.reload(year:month:)` ([Hibi/Models/EventStore.swift](Hibi/Models/EventStore.swift))

Replaced the single-bucket `calendar.component(.day, from: ek.startDate)` mapping with a loop over each day-of-month the event's `[startDate, endDate)` overlaps, clamped to the loaded month's window.

- All-day events: EK's exclusive-midnight end is respected (an Apr 18 all-day event ends at Apr 19 00:00 and doesn't bleed into Apr 19).
- Timed events ending exactly at midnight don't spill into the next day.
- Cross-month events populate only the days that belong to the month currently being reloaded.

`allLoadedEvents()` now dedupes by `event.id`, keeping the earliest instance, so search returns one hit per event rather than one per spanned day.

### Drag-and-drop in the week view ([Hibi/Views/StreamView.swift](Hibi/Views/StreamView.swift), [Hibi/Models/EventStore.swift](Hibi/Models/EventStore.swift))

- New `DraggedEvent: Transferable` payload carries `eventIdentifier` + source `(year, month, day)` so the store can tell which instance of a multi-day event the user grabbed.
- Each event button gets `.draggable { DraggedEvent(...) }` with a preview. Demo fixtures and events missing an EK identifier opt out.
- Each `StreamDayRow` gains `.dropDestination(for: DraggedEvent.self)` with a subtle row highlight while targeted.
- New `EventStore.moveEventInstance(identifier:from:to:)` applies the day delta:
  - Single-day event → shift both dates (duration preserved).
  - Multi-day, drag the **first-day instance** → move `startDate`.
  - Multi-day, drag the **last-day instance** → move `endDate` (the extension case described in #9).
  - Multi-day, drag a **middle day** → move the boundary in the drag's direction.
- Save goes through `ekStore.save(_:span: .thisEvent)`; the existing `.EKEventStoreChanged` observer handles the refresh.

## Test plan

- [ ] Grant full calendar access. Add a timed event that spans two days (e.g., 23:00 → 01:00) and confirm it shows on both days in month/week/day views.
- [ ] Add a multi-day all-day event and verify every day of the span renders it (and the day after the last is clean).
- [ ] Create an event that crosses a month boundary; scroll through both months and confirm each month only shows its own days.
- [ ] Search for a multi-day event — result appears once, pointing to the first day.
- [ ] In the week view, long-press a single-day event and drop it on another day — whole event moves, duration preserved.
- [ ] Long-press the last-day instance of a 2-day event and drop it two days later — event now spans four days and the intermediate days fill in.
- [ ] Long-press the first-day instance and drop it earlier — `startDate` moves back, intermediate days fill in.
- [ ] Drop on the source day — no-op (no save, no flicker).
- [ ] Demo mode: events are not draggable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)