### PR TITLE
Use Noto Serif JP as display face in Japanese locale

### DIFF
--- a/Hibi/HibiApp.swift
+++ b/Hibi/HibiApp.swift
@@ -14,9 +14,13 @@ struct HibiApp: App {
     }
 
     private static func registerFonts() {
-        let names = ["InstrumentSerif-Regular", "InstrumentSerif-Italic"]
-        for name in names {
-            guard let url = Bundle.main.url(forResource: name, withExtension: "ttf") else {
+        let fonts: [(name: String, ext: String)] = [
+            ("InstrumentSerif-Regular", "ttf"),
+            ("InstrumentSerif-Italic", "ttf"),
+            ("NotoSerifJP-Regular", "otf"),
+        ]
+        for font in fonts {
+            guard let url = Bundle.main.url(forResource: font.name, withExtension: font.ext) else {
                 continue
             }
             var error: Unmanaged<CFError>?

--- a/Hibi/Models/SampleData.swift
+++ b/Hibi/Models/SampleData.swift
@@ -98,14 +98,36 @@ enum AppColor {
 enum AppFont {
     static let serifRegular = "InstrumentSerif-Regular"
     static let serifItalic  = "InstrumentSerif-Italic"
+    /// Noto Serif JP Regular. Used for the entire display face when the user's
+    /// preferred language is Japanese — Instrument Serif is Latin-only and
+    /// would otherwise fall back to the system default for kana/kanji. Noto
+    /// CJK ships no italic; callers that want italic in a Japanese locale get
+    /// synthesized skew via `Font.italic()`.
+    static let serifJP = "NotoSerifJP-Regular"
+
+    /// True when the user's preferred UI language resolves to Japanese.
+    /// Read from `Locale.preferredLanguages` (what the app actually renders
+    /// in) rather than `Locale.current`, which on this project is pinned to
+    /// `de_DE` for calendar math.
+    static var isJapaneseLocale: Bool {
+        guard let first = Locale.preferredLanguages.first else { return false }
+        return Locale(identifier: first).language.languageCode?.identifier == "ja"
+    }
 }
 
 extension Font {
     /// App display font. `simple` swaps Instrument Serif for the system
     /// sans-serif face (driven by the "useSimpleFont" AppStorage toggle).
+    /// In a Japanese locale the serif face is Noto Serif JP (Latin-only
+    /// Instrument Serif can't render kana/kanji); italic is synthesized since
+    /// Noto CJK has no italic cut.
     static func appSerif(size: CGFloat, italic: Bool = false, simple: Bool) -> Font {
         if simple {
             let base = Font.system(size: size)
+            return italic ? base.italic() : base
+        }
+        if AppFont.isJapaneseLocale {
+            let base = Font.custom(AppFont.serifJP, size: size)
             return italic ? base.italic() : base
         }
         return .custom(italic ? AppFont.serifItalic : AppFont.serifRegular, size: size)


### PR DESCRIPTION
## Summary

- Bundle **Noto Serif JP Regular** (from [notofonts/noto-cjk](https://github.com/notofonts/noto-cjk)) at `Hibi/Fonts/NotoSerifJP-Regular.otf` and register it at launch in `HibiApp.registerFonts()`.
- `Font.appSerif` now swaps to Noto Serif JP when the user's preferred UI language resolves to Japanese. Latin locales keep Instrument Serif unchanged.
- Italic is synthesized via `Font.italic()` for the JP branch since Noto CJK ships no italic cut.

## Why

Instrument Serif is a Latin-only face, so in a Japanese locale kana/kanji were falling back to the system default font — visually inconsistent with the editorial Instrument Serif used everywhere else. Noto Serif JP is a purpose-built serif for Japanese and pairs well with the existing display style.

## Notes for reviewers

- Detection uses `Locale.preferredLanguages.first` rather than `Locale.current`. This project pins `Locale` to `de_DE` in the stores for calendar math (see `AGENTS.md` gotchas), so `Locale.current` would give the wrong answer for UI-language decisions.
- The font file is ~6 MB (a JP subset of Noto CJK Serif). The project uses `PBXFileSystemSynchronizedRootGroup`, so no pbxproj edits were needed — Xcode auto-picks it up from `Hibi/Fonts/`.
- `AppFont.serifRegular` / `AppFont.serifItalic` string constants are unchanged, so no callers need updates; the swap happens inside `Font.appSerif`.

## Test plan

- [ ] Build and run on a simulator with Language set to **English** → month/day/event text still renders in Instrument Serif.
- [ ] Set simulator Language to **Japanese (日本語)** → month names (`4月`), weekday headers, and event text render in Noto Serif JP instead of the system sans-serif fallback.
- [ ] Verify the "Simple font" toggle in Settings still bypasses both serif faces and uses the system sans-serif.

🤖 Generated with [Claude Code](https://claude.com/claude-code)