### PR TITLE
fix: seed Month view on today instead of the shared binding

### DIFF
--- a/Hibi/Views/MonthView.swift
+++ b/Hibi/Views/MonthView.swift
@@ -158,9 +158,12 @@ struct MonthsScrollView: View {
         self._displayedMonth = displayedMonth
         self.scrollToNowToken = scrollToNowToken
         self.onPickDay = onPickDay
+        // Seed on today, not the binding: the binding can drift when the Week
+        // view has been scrolled before the Month tab is first opened, which
+        // otherwise lands Month on whatever month Week was showing.
         let seed = MonthKey(
-            year: displayedYear.wrappedValue,
-            month: displayedMonth.wrappedValue
+            year: SampleData.todayYear,
+            month: SampleData.todayMonth
         )
         _window = State(initialValue: CalendarWindow(center: seed))
         var initial = ScrollPosition(idType: Int.self)


### PR DESCRIPTION
The Week view writes its visible month back into displayedMonth as it
scrolls. If the user scrolled Week before opening Month for the first
time, MonthsScrollView.init would seed its window + ScrollPosition from
that drifted binding and land on the wrong month.

https://claude.ai/code/session_015xVmyTLvjEjaWR1TuG5cC3