### PR TITLE
Stop stream scroll from jumping a few days after magnetic snap

### DIFF
--- a/Hibi/Views/MonthView.swift
+++ b/Hibi/Views/MonthView.swift
@@ -194,7 +194,11 @@ struct MonthsScrollView: View {
         .onScrollPhaseChange { _, newPhase in
             if newPhase == .idle {
                 let id = position.viewID(type: Int.self) ?? window.visibleMonthID
-                window.extendIfNearEdge(visibleID: id)
+                // Re-pin the visible month after inserting rows so `.viewAligned`
+                // can't snap to a neighbour on the newly shifted layout.
+                if window.extendIfNearEdge(visibleID: id), let id {
+                    position.scrollTo(id: id)
+                }
             }
         }
         .onChange(of: position.viewID(type: Int.self)) { _, newID in
@@ -277,10 +281,13 @@ final class CalendarWindow {
         self.visibleMonthID = center.id
     }
 
-    func extendIfNearEdge(visibleID: MonthKey.ID?) {
+    /// Returns `true` when the window was mutated, so the caller can re-anchor
+    /// the scroll position before `.viewAligned` decides to snap to a neighbour.
+    @discardableResult
+    func extendIfNearEdge(visibleID: MonthKey.ID?) -> Bool {
         guard !isExtending,
               let id = visibleID,
-              let idx = months.firstIndex(where: { $0.id == id }) else { return }
+              let idx = months.firstIndex(where: { $0.id == id }) else { return false }
 
         let neededAbove = windowRadius - idx
         let neededBelow = windowRadius - (months.count - 1 - idx)
@@ -295,6 +302,7 @@ final class CalendarWindow {
             months.insert(contentsOf: prepended, at: 0)
             trimTrailingIfOverflow()
             isExtending = false
+            return true
         } else if neededBelow > 0, let last = months.last {
             isExtending = true
             let count = min(neededBelow, cap)
@@ -304,7 +312,9 @@ final class CalendarWindow {
             months.append(contentsOf: appended)
             trimLeadingIfOverflow()
             isExtending = false
+            return true
         }
+        return false
     }
 
     func recenter(on key: MonthKey) {

--- a/Hibi/Views/StreamView.swift
+++ b/Hibi/Views/StreamView.swift
@@ -86,7 +86,24 @@ struct StreamView: View {
         .onScrollPhaseChange { _, newPhase in
             if newPhase == .idle {
                 let id = position.viewID(type: Int.self) ?? window.visibleDayID
-                window.extendIfNearEdge(visibleID: id)
+                // After inserting rows, the viewport's content offset shifts to
+                // keep the centered day centered — but `.viewAligned` may still
+                // decide to snap to a neighbour because the new layout lands a
+                // few pixels off-grid. Re-pinning to the same id pre-empts that
+                // snap, which the user saw as "jumping a few days after slowing
+                // down."
+                if window.extendIfNearEdge(visibleID: id), let id {
+                    position.scrollTo(id: id)
+                }
+            }
+        }
+        .task(id: windowMonthsSignature) {
+            var seen = Set<MonthKey>()
+            for key in window.days {
+                let month = MonthKey(year: key.year, month: key.month)
+                if seen.insert(month).inserted {
+                    eventStore.ensureLoaded(year: month.year, month: month.month)
+                }
             }
         }
         .onChange(of: position.viewID(type: Int.self)) { _, newID in
@@ -108,6 +125,14 @@ struct StreamView: View {
                 position.scrollTo(id: today.id)
             }
         }
+    }
+
+    // Signature that changes only when the window's month range changes, so the
+    // preload `.task` re-fires on extension but not on every scroll tick.
+    private var windowMonthsSignature: Int {
+        let first = window.days.first.map { $0.year * 100 + $0.month } ?? 0
+        let last = window.days.last.map { $0.year * 100 + $0.month } ?? 0
+        return first &* 1_000_000 &+ last
     }
 }
 
@@ -161,10 +186,13 @@ final class StreamWindow {
         self.visibleDayID = center.id
     }
 
-    func extendIfNearEdge(visibleID: DayKey.ID?) {
+    /// Returns `true` when the window was mutated, so the caller can re-anchor
+    /// the scroll position before `.viewAligned` decides to snap to a neighbour.
+    @discardableResult
+    func extendIfNearEdge(visibleID: DayKey.ID?) -> Bool {
         guard !isExtending,
               let id = visibleID,
-              let idx = days.firstIndex(where: { $0.id == id }) else { return }
+              let idx = days.firstIndex(where: { $0.id == id }) else { return false }
 
         let neededAbove = windowRadius - idx
         let neededBelow = windowRadius - (days.count - 1 - idx)
@@ -179,6 +207,7 @@ final class StreamWindow {
             days.insert(contentsOf: prepended, at: 0)
             trimTrailingIfOverflow()
             isExtending = false
+            return true
         } else if neededBelow > 0, let last = days.last {
             isExtending = true
             let count = min(neededBelow, cap)
@@ -186,7 +215,9 @@ final class StreamWindow {
             days.append(contentsOf: appended)
             trimLeadingIfOverflow()
             isExtending = false
+            return true
         }
+        return false
     }
 
     func recenter(on key: DayKey) {

--- a/learnings.md
+++ b/learnings.md
@@ -28,6 +28,20 @@ A fixed-length ForEach over a huge range (e.g. `ForEach(-600...600)`) does not w
 
 Instead of "when near edge, add N items," maintain an **invariant**: always keep ≥ `windowRadius` items on each side of the visible item. `extendIfNearEdge` computes `neededAbove` / `neededBelow` and refills exactly that many (capped by `extendBatch`). This is self-throttling — extensions stop as soon as the buffer is restored, regardless of how the user scrolls.
 
+## Re-anchor after window extension to stop `.viewAligned` re-snapping
+
+**Symptom we hit:** scrolling the Week stream would "jump a few days" right as the fling settled. Small, occasional, always at the end of a scroll.
+
+**Cause:** when `onScrollPhaseChange` hits `.idle` near an edge, we prepend/append rows. `.scrollPosition(anchor: .center)` does re-center the pinned id, but the new layout lands a handful of pixels off the `.viewAligned` grid, so the scroll behavior animates a corrective snap — often landing on the neighbouring day/month.
+
+**Fix:** have `extendIfNearEdge` return `Bool` and, when it mutated the window, immediately call `position.scrollTo(id: pinnedID)`. The imperative command is queued after the data change and pre-empts `.viewAligned`'s snap. Cheap, no animation needed.
+
+## Preload the window's months so row heights don't shift mid-deceleration
+
+**Symptom we hit:** `StreamDayRow` has variable height (`minHeight: events.isEmpty ? 92 : nil`). `ensureLoaded` is triggered per-row via `.task(id: MonthKey(...))`, so on a fast scroll into an unseen month, rows first render empty (92pt) and grow a frame or two later once EventKit returns. If that height change lands during deceleration, `.viewAligned` recomputes its snap target against the new layout — user sees a jump.
+
+**Fix:** drive `ensureLoaded` from the window itself with `.task(id: windowMonthsSignature)` over the unique `MonthKey`s in `window.days`. Re-fires on extend, not on every scroll tick. Events are cached before the row even appears, so heights are stable when the scroll arrives.
+
 ## `ScrollPosition` (imperative) beats `scrollPosition(id: $binding)` for programmatic scroll
 
 **Symptom we hit:** tapping the active tab ("return to now") flakily jumped to the start of the list instead of today.


### PR DESCRIPTION
## Summary

Fixes the "sometimes when scrolling, it jumps a few days after slowing down" bug in the Week stream (and the analogous, rarer jump in Month view).

Two root causes, both tied to `.scrollTargetBehavior(.viewAligned)`:

- **Extension + re-snap.** When `onScrollPhaseChange` hits `.idle` near an edge, we prepend/append rows. `.scrollPosition(anchor: .center)` re-centers the pinned id, but the new layout lands a few pixels off the view-aligned grid, so the scroll behavior animates a corrective snap — often onto the neighbouring day.
- **Async row height growth.** `StreamDayRow` has variable height (`minHeight: events.isEmpty ? 92 : nil`) and `ensureLoaded` is triggered per-row via `.task(id: MonthKey(...))`. On a fast scroll into an unseen month, rows first render empty (92pt) and grow a frame later when EventKit returns — shifting `.viewAligned`'s snap target mid-deceleration.

## Changes

- `StreamWindow.extendIfNearEdge` / `CalendarWindow.extendIfNearEdge` now return `Bool`. When `true`, the scroll view re-pins via `position.scrollTo(id:)`, which is queued after the data change and pre-empts the corrective snap. No animation needed.
- `StreamView` gains `.task(id: windowMonthsSignature)` that walks the unique `MonthKey`s in `window.days` and eagerly calls `eventStore.ensureLoaded`. `ensureLoaded` is a cheap no-op when already cached; the signature only changes when the window's month range changes, so this re-fires on extend, not on every scroll tick.
- Documented both in `learnings.md` next to the existing infinite-scroll notes.

## Test plan

- [ ] Week tab: scroll fast, let it decelerate, confirm no "jump a few days" as it settles.
- [ ] Week tab: scroll past the initial 60-day radius in both directions; window should extend without visible jump.
- [ ] Week tab: tap the active Week tab to return to today; still glides to today.
- [ ] Month tab: same checks — no jump on extend, return-to-now still works.
- [ ] Verify row heights are stable when scrolling into months with events (no growing-in after landing).

https://claude.ai/code/session_017SEmzEkwguXHGkZ7QTWjVx