### PR TITLE
route permissions through PermissionsKit

### DIFF
--- a/Hibi.xcodeproj/project.pbxproj
+++ b/Hibi.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		4B0450C42F94C6EF009EA06E /* WhatsNewKit in Frameworks */ = {isa = PBXBuildFile; productRef = 4B0450C32F94C6EF009EA06E /* WhatsNewKit */; };
+		4B0451032F94C6EF009EA06E /* CalendarPermission in Frameworks */ = {isa = PBXBuildFile; productRef = 4B0451012F94C6EF009EA06E /* CalendarPermission */; };
+		4B0451042F94C6EF009EA06E /* LocationPermission in Frameworks */ = {isa = PBXBuildFile; productRef = 4B0451022F94C6EF009EA06E /* LocationPermission */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -28,6 +30,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				4B0450C42F94C6EF009EA06E /* WhatsNewKit in Frameworks */,
+				4B0451032F94C6EF009EA06E /* CalendarPermission in Frameworks */,
+				4B0451042F94C6EF009EA06E /* LocationPermission in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -71,6 +75,8 @@
 			name = Hibi;
 			packageProductDependencies = (
 				4B0450C32F94C6EF009EA06E /* WhatsNewKit */,
+				4B0451012F94C6EF009EA06E /* CalendarPermission */,
+				4B0451022F94C6EF009EA06E /* LocationPermission */,
 			);
 			productName = Hibi;
 			productReference = 4B802FCD2F8F5453008F00F4 /* Hibi.app */;
@@ -104,6 +110,7 @@
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
 				4B0450C22F94C6EF009EA06E /* XCRemoteSwiftPackageReference "WhatsNewKit" */,
+				4B0451002F94C6EF009EA06E /* XCRemoteSwiftPackageReference "PermissionsKit" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 4B802FCE2F8F5453008F00F4 /* Products */;
@@ -377,6 +384,14 @@
 				minimumVersion = 2.2.1;
 			};
 		};
+		4B0451002F94C6EF009EA06E /* XCRemoteSwiftPackageReference "PermissionsKit" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/sparrowcode/PermissionsKit";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 11.1.0;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -384,6 +399,16 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 4B0450C22F94C6EF009EA06E /* XCRemoteSwiftPackageReference "WhatsNewKit" */;
 			productName = WhatsNewKit;
+		};
+		4B0451012F94C6EF009EA06E /* CalendarPermission */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 4B0451002F94C6EF009EA06E /* XCRemoteSwiftPackageReference "PermissionsKit" */;
+			productName = CalendarPermission;
+		};
+		4B0451022F94C6EF009EA06E /* LocationPermission */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 4B0451002F94C6EF009EA06E /* XCRemoteSwiftPackageReference "PermissionsKit" */;
+			productName = LocationPermission;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Hibi.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Hibi.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -2,6 +2,15 @@
   "originHash" : "ed22328b129bd017fa539332038d160d3ad840f3c250e30a08e90e5d89459ba0",
   "pins" : [
     {
+      "identity" : "permissionskit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sparrowcode/PermissionsKit",
+      "state" : {
+        "revision" : "5e5935998cf9c44033e429c3b7d1dd176a1f55ad",
+        "version" : "11.1.0"
+      }
+    },
+    {
       "identity" : "whatsnewkit",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SvenTiigi/WhatsNewKit",

--- a/Hibi/ContentView.swift
+++ b/Hibi/ContentView.swift
@@ -15,6 +15,7 @@ struct ContentView: View {
     @State private var eventStore = EventStore()
     @State private var weatherStore = WeatherStore()
     @State private var editorMode: EventEditorSheet.Mode?
+    @State private var showOnboarding = false
     @Environment(\.scenePhase) private var scenePhase
     @AppStorage("appearance") private var appearanceRaw: String = SettingsView.Appearance.system.rawValue
     @AppStorage("useSimpleFont") private var useSimpleFont: Bool = false
@@ -107,7 +108,7 @@ struct ContentView: View {
                     .disabled(eventStore.isDemoMode || !eventStore.hasCalendarAccess)
                 }
             }
-            .background(backgroundGradient.ignoresSafeArea())
+            .background(AppBackgroundGradient().ignoresSafeArea())
         }
         .environment(eventStore)
         .environment(weatherStore)
@@ -122,13 +123,22 @@ struct ContentView: View {
             }
             .ignoresSafeArea()
         }
-        .task {
-            if !eventStore.hasCalendarAccess, !eventStore.isDemoMode {
-                await eventStore.requestAccess()
-            }
+        .sheet(isPresented: $showOnboarding, onDismiss: {
             eventStore.ensureLoaded(year: displayedYear, month: displayedMonth)
-            weatherStore.requestAccess()
             weatherStore.refresh()
+        }) {
+            PermissionsOnboardingSheet(
+                items: onboardingItems,
+                onContinue: { }
+            )
+        }
+        .task {
+            eventStore.ensureLoaded(year: displayedYear, month: displayedMonth)
+            weatherStore.refresh()
+            if !eventStore.isDemoMode,
+               (!eventStore.hasCalendarAccess || !weatherStore.hasLocationAccess) {
+                showOnboarding = true
+            }
         }
         .onChange(of: displayedYear) { _, _ in
             eventStore.ensureLoaded(year: displayedYear, month: displayedMonth)
@@ -166,30 +176,31 @@ struct ContentView: View {
         editorMode = .new(defaultStart: date)
     }
 
-    @ViewBuilder
-    private var backgroundGradient: some View {
-        if colorScheme == .dark {
-            RadialGradient(
-                colors: [
-                    Color(.displayP3, red: 0.102, green: 0.102, blue: 0.122),
-                    Color(.displayP3, red: 0.047, green: 0.047, blue: 0.055),
-                ],
-                center: UnitPoint(x: 0.2, y: 0.0),
-                startRadius: 0,
-                endRadius: 600
-            )
-        } else {
-            RadialGradient(
-                colors: [
-                    Color(.displayP3, red: 0.984, green: 0.980, blue: 0.965),
-                    Color(.displayP3, red: 0.953, green: 0.945, blue: 0.918),
-                    Color(.displayP3, red: 0.929, green: 0.914, blue: 0.867),
-                ],
-                center: UnitPoint(x: 0.15, y: -0.1),
-                startRadius: 0,
-                endRadius: 700
-            )
-        }
+    private var onboardingItems: [PermissionOnboardingItem] {
+        [
+            PermissionOnboardingItem(
+                id: "calendar",
+                icon: "calendar",
+                tint: Color(.displayP3, red: 0.78, green: 0.49, blue: 0.42, opacity: 1),
+                title: "Calendar",
+                description: "Show and edit the events from your system calendars.",
+                isGranted: { eventStore.hasCalendarAccess },
+                isDenied: { eventStore.calendarAccessDenied },
+                request: { await eventStore.requestAccess() },
+                openSettings: { eventStore.openCalendarSettings() }
+            ),
+            PermissionOnboardingItem(
+                id: "location",
+                icon: "location.fill",
+                tint: Color(.displayP3, red: 0.38, green: 0.55, blue: 0.76, opacity: 1),
+                title: "Location",
+                description: "Local weather and sunrise / sunset on each day.",
+                isGranted: { weatherStore.hasLocationAccess },
+                isDenied: { weatherStore.locationAccessDenied },
+                request: { await weatherStore.requestAccess() },
+                openSettings: { weatherStore.openLocationSettings() }
+            ),
+        ]
     }
 
     private var colorScheme: ColorScheme? {

--- a/Hibi/ContentView.swift
+++ b/Hibi/ContentView.swift
@@ -16,6 +16,10 @@ struct ContentView: View {
     @State private var weatherStore = WeatherStore()
     @State private var editorMode: EventEditorSheet.Mode?
     @State private var showOnboarding = false
+    /// Latched by SettingsView — when Settings dismisses with this set we
+    /// present the onboarding sheet. Can't show two sheets at once, so we
+    /// chain via `onDismiss`.
+    @State private var reopenOnboardingAfterSettings = false
     @Environment(\.scenePhase) private var scenePhase
     @AppStorage("appearance") private var appearanceRaw: String = SettingsView.Appearance.system.rawValue
     @AppStorage("useSimpleFont") private var useSimpleFont: Bool = false
@@ -113,9 +117,19 @@ struct ContentView: View {
         .environment(eventStore)
         .environment(weatherStore)
         .whatsNewSheet()
-        .sheet(isPresented: $showSettings) {
-            SettingsView()
-                .environment(eventStore)
+        .sheet(isPresented: $showSettings, onDismiss: {
+            if reopenOnboardingAfterSettings {
+                reopenOnboardingAfterSettings = false
+                showOnboarding = true
+            }
+        }) {
+            SettingsView(
+                onReopenPermissions: {
+                    reopenOnboardingAfterSettings = true
+                }
+            )
+            .environment(eventStore)
+            .environment(weatherStore)
         }
         .sheet(item: $editorMode) { mode in
             EventEditorSheet(store: eventStore.ekStore, mode: mode) {
@@ -135,8 +149,9 @@ struct ContentView: View {
         .task {
             eventStore.ensureLoaded(year: displayedYear, month: displayedMonth)
             weatherStore.refresh()
-            if !eventStore.isDemoMode,
-               (!eventStore.hasCalendarAccess || !weatherStore.hasLocationAccess) {
+            // Auto-present only when a REQUIRED permission is missing.
+            // Location is optional — users enable it later from Settings.
+            if !eventStore.isDemoMode, !eventStore.hasCalendarAccess {
                 showOnboarding = true
             }
         }
@@ -145,6 +160,14 @@ struct ContentView: View {
         }
         .onChange(of: displayedMonth) { _, _ in
             eventStore.ensureLoaded(year: displayedYear, month: displayedMonth)
+        }
+        .onChange(of: eventStore.hasCalendarAccess) { _, newValue in
+            // Cover any path that flips access on — inline CalendarAccessPrompt,
+            // Settings toggle, or onboarding sheet. ensureLoaded only fetches
+            // months not yet in the cache, so this is cheap and idempotent.
+            if newValue {
+                eventStore.ensureLoaded(year: displayedYear, month: displayedMonth)
+            }
         }
         .onChange(of: scenePhase) { _, phase in
             if phase == .active {
@@ -184,6 +207,7 @@ struct ContentView: View {
                 tint: Color(.displayP3, red: 0.78, green: 0.49, blue: 0.42, opacity: 1),
                 title: "Calendar",
                 description: "Show and edit the events from your system calendars.",
+                isRequired: true,
                 isGranted: { eventStore.hasCalendarAccess },
                 isDenied: { eventStore.calendarAccessDenied },
                 request: { await eventStore.requestAccess() },
@@ -195,6 +219,7 @@ struct ContentView: View {
                 tint: Color(.displayP3, red: 0.38, green: 0.55, blue: 0.76, opacity: 1),
                 title: "Location",
                 description: "Local weather and sunrise / sunset on each day.",
+                isRequired: false,
                 isGranted: { weatherStore.hasLocationAccess },
                 isDenied: { weatherStore.locationAccessDenied },
                 request: { await weatherStore.requestAccess() },

--- a/Hibi/ContentView.swift
+++ b/Hibi/ContentView.swift
@@ -1,4 +1,3 @@
-import EventKit
 import SwiftUI
 import WhatsNewKit
 
@@ -105,7 +104,7 @@ struct ContentView: View {
                     } label: {
                         Image(systemName: "plus")
                     }
-                    .disabled(eventStore.isDemoMode || eventStore.authorization != .fullAccess)
+                    .disabled(eventStore.isDemoMode || !eventStore.hasCalendarAccess)
                 }
             }
             .background(backgroundGradient.ignoresSafeArea())
@@ -124,7 +123,7 @@ struct ContentView: View {
             .ignoresSafeArea()
         }
         .task {
-            if eventStore.authorization != .fullAccess, !eventStore.isDemoMode {
+            if !eventStore.hasCalendarAccess, !eventStore.isDemoMode {
                 await eventStore.requestAccess()
             }
             eventStore.ensureLoaded(year: displayedYear, month: displayedMonth)
@@ -138,7 +137,10 @@ struct ContentView: View {
             eventStore.ensureLoaded(year: displayedYear, month: displayedMonth)
         }
         .onChange(of: scenePhase) { _, phase in
-            if phase == .active { weatherStore.refresh() }
+            if phase == .active {
+                eventStore.refreshAccessFromScenePhase()
+                weatherStore.refresh()
+            }
         }
         .preferredColorScheme(colorScheme)
         .tint(.primary)

--- a/Hibi/HibiApp.swift
+++ b/Hibi/HibiApp.swift
@@ -4,18 +4,35 @@ import WhatsNewKit
 
 @main
 struct HibiApp: App {
+    private let whatsNewEnvironment: WhatsNewEnvironment
+
     init() {
         Self.registerFonts()
+        self.whatsNewEnvironment = Self.makeWhatsNewEnvironment()
     }
 
     var body: some Scene {
         WindowGroup {
             ContentView()
-                .environment(
-                    \.whatsNew,
-                    WhatsNewEnvironment(whatsNewCollection: WhatsNewContent.collection)
-                )
+                .environment(\.whatsNew, whatsNewEnvironment)
         }
+    }
+
+    /// Fresh installs should not see the What's New sheet — it's meant for
+    /// updates. On the very first launch we mark the current version as
+    /// already presented, so WhatsNewKit only fires on subsequent upgrades.
+    private static func makeWhatsNewEnvironment() -> WhatsNewEnvironment {
+        let versionStore = UserDefaultsWhatsNewVersionStore()
+        let defaults = UserDefaults.standard
+        let firstLaunchKey = "hasLaunchedBefore"
+        if !defaults.bool(forKey: firstLaunchKey) {
+            versionStore.save(presentedVersion: WhatsNewContent.version)
+            defaults.set(true, forKey: firstLaunchKey)
+        }
+        return WhatsNewEnvironment(
+            versionStore: versionStore,
+            whatsNewCollection: WhatsNewContent.collection
+        )
     }
 
     private static func registerFonts() {

--- a/Hibi/Localizable.xcstrings
+++ b/Hibi/Localizable.xcstrings
@@ -25,6 +25,33 @@
         }
       }
     },
+    "A couple of permissions so Hibi can do its thing." : {
+
+    },
+    "A new Settings toggle swaps the serif for the system sans, for a cleaner read." : {
+      "comment" : "What's New 1.1 — Simple-font feature subtitle.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ein neuer Schalter in den Einstellungen tauscht die Serifenschrift gegen die Systemschrift – für ein klareres Schriftbild."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "A new Settings toggle swaps the serif for the system sans, for a cleaner read."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "設定の新しいスイッチで、セリフ体をシステムのサンセリフ体に切り替えられます。読みやすさ重視のときに。"
+          }
+        }
+      }
+    },
     "All day" : {
       "comment" : "Event subtitle for an all-day event (sentence case, used in a list row subtitle).",
       "extractionState" : "manual",
@@ -73,6 +100,12 @@
         }
       }
     },
+    "All set" : {
+
+    },
+    "Allow" : {
+
+    },
     "An open day." : {
       "comment" : "Day tab empty state when no events are scheduled.",
       "extractionState" : "manual",
@@ -120,6 +153,9 @@
           }
         }
       }
+    },
+    "Calendar" : {
+
     },
     "Calendar access denied" : {
       "comment" : "Error title when the user has denied Calendar access.",
@@ -193,102 +229,6 @@
         }
       }
     },
-    "Day View" : {
-      "comment" : "Settings section header for Day-tab-specific options.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tagesansicht"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Day View"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "日表示"
-          }
-        }
-      }
-    },
-    "Invert swipe direction" : {
-      "comment" : "Toggle label in Settings → Day View: flips tear-up-for-next gesture.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wischrichtung umkehren"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Invert swipe direction"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "スワイプ方向を反転"
-          }
-        }
-      }
-    },
-    "PULL TO TEAR · ↑ PREV · ↓ NEXT" : {
-      "comment" : "Day tab hint text when the invert-swipe setting is on. Uppercase tracked caps.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ZIEHEN ZUM ABREISSEN · ↑ ZURÜCK · ↓ WEITER"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "PULL TO TEAR · ↑ PREV · ↓ NEXT"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "めくる · ↑ 前の日 · ↓ 次の日"
-          }
-        }
-      }
-    },
-    "Simple font" : {
-      "comment" : "Toggle label in Settings → Appearance: swap Instrument Serif for system sans.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Einfache Schrift"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Simple font"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "シンプルなフォント"
-          }
-        }
-      }
-    },
     "Calendars" : {
       "comment" : "Settings section header and row label for the Calendars picker screen.",
       "extractionState" : "manual",
@@ -309,6 +249,30 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "カレンダー"
+          }
+        }
+      }
+    },
+    "Continue" : {
+      "comment" : "What's New 1.1 — primary action that dismisses the sheet.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Weiter"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Continue"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "続ける"
           }
         }
       }
@@ -357,6 +321,30 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "日"
+          }
+        }
+      }
+    },
+    "Day View" : {
+      "comment" : "Settings section header for Day-tab-specific options.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tagesansicht"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Day View"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "日表示"
           }
         }
       }
@@ -433,6 +421,30 @@
         }
       }
     },
+    "Deutsch & 日本語" : {
+      "comment" : "What's New 1.1 — localization feature title; kept identical across locales.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Deutsch & 日本語"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Deutsch & 日本語"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Deutsch & 日本語"
+          }
+        }
+      }
+    },
     "Done" : {
       "comment" : "Toolbar button label that dismisses the Settings sheet.",
       "extractionState" : "manual",
@@ -453,6 +465,30 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "完了"
+          }
+        }
+      }
+    },
+    "Drag to reschedule" : {
+      "comment" : "What's New 1.1 — drag-to-move feature title.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ziehen zum Verschieben"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Drag to reschedule"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ドラッグで予定を移動"
           }
         }
       }
@@ -505,6 +541,30 @@
         }
       }
     },
+    "Events spanning several days now appear on every day they cover, across Month, Week, and Day." : {
+      "comment" : "What's New 1.1 — multi-day events feature subtitle.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Termine über mehrere Tage erscheinen jetzt an jedem betroffenen Tag – in Monat, Woche und Tag."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Events spanning several days now appear on every day they cover, across Month, Week, and Day."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "複数日にまたがるイベントが、月・週・日のすべてで該当する各日に表示されます。"
+          }
+        }
+      }
+    },
     "Find events by title or location." : {
       "comment" : "Empty state subtitle shown in the search results view.",
       "extractionState" : "manual",
@@ -525,6 +585,30 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "タイトルや場所でイベントを検索します。"
+          }
+        }
+      }
+    },
+    "Flip the swipe" : {
+      "comment" : "What's New 1.1 — invert-swipe-direction feature title.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wischrichtung umkehren"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Flip the swipe"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "スワイプ方向を反転"
           }
         }
       }
@@ -601,6 +685,54 @@
         }
       }
     },
+    "Hibi now speaks German and Japanese, with locale-appropriate week-start and time format." : {
+      "comment" : "What's New 1.1 — localization feature subtitle.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hibi spricht jetzt Deutsch und Japanisch – mit passendem Wochenstart und Zeitformat."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hibi now speaks German and Japanese, with locale-appropriate week-start and time format."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hibi がドイツ語と日本語に対応しました。週の始まりと時刻表記もロケールに合わせて切り替わります。"
+          }
+        }
+      }
+    },
+    "Invert swipe direction" : {
+      "comment" : "Toggle label in Settings → Day View: flips tear-up-for-next gesture.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wischrichtung umkehren"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Invert swipe direction"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "スワイプ方向を反転"
+          }
+        }
+      }
+    },
     "Light" : {
       "comment" : "Appearance picker option: always use the light theme.",
       "extractionState" : "manual",
@@ -625,6 +757,36 @@
         }
       }
     },
+    "Local weather and sunrise / sunset on each day." : {
+
+    },
+    "Location" : {
+
+    },
+    "Long-press an event in the Week view and drop it on another day to move it." : {
+      "comment" : "What's New 1.1 — drag-to-move feature subtitle.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Halte einen Termin in der Wochenansicht gedrückt und ziehe ihn auf einen anderen Tag, um ihn zu verschieben."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Long-press an event in the Week view and drop it on another day to move it."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "週ビューでイベントを長押しし、別の日にドロップすると移動できます。"
+          }
+        }
+      }
+    },
     "Month" : {
       "comment" : "Tab bar label for the Month tab.",
       "extractionState" : "manual",
@@ -645,6 +807,30 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "月"
+          }
+        }
+      }
+    },
+    "Multi-day events" : {
+      "comment" : "What's New 1.1 — multi-day events feature title.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mehrtägige Termine"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Multi-day events"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "複数日のイベント"
           }
         }
       }
@@ -769,6 +955,33 @@
         }
       }
     },
+    "Permissions" : {
+
+    },
+    "Prefer swipe-up to go back? Invert the Day-view tear direction in Settings." : {
+      "comment" : "What's New 1.1 — invert-swipe-direction feature subtitle.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lieber nach oben wischen, um zurückzugehen? Kehre die Abreißrichtung der Tagesansicht in den Einstellungen um."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Prefer swipe-up to go back? Invert the Day-view tear direction in Settings."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "上方向へのスワイプで戻りたい場合は、設定で日ビューの切り取り方向を反転できます。"
+          }
+        }
+      }
+    },
     "PULL TO TEAR · ↑ NEXT · ↓ PREV" : {
       "comment" : "Day tab hint text above the tear-off paper stack. Uppercase tracked caps.",
       "extractionState" : "manual",
@@ -792,6 +1005,33 @@
           }
         }
       }
+    },
+    "PULL TO TEAR · ↑ PREV · ↓ NEXT" : {
+      "comment" : "Day tab hint text when the invert-swipe setting is on. Uppercase tracked caps.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ZIEHEN ZUM ABREISSEN · ↑ ZURÜCK · ↓ WEITER"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "PULL TO TEAR · ↑ PREV · ↓ NEXT"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "めくる · ↑ 前の日 · ↓ 次の日"
+          }
+        }
+      }
+    },
+    "Review permissions" : {
+
     },
     "SCHEDULE" : {
       "comment" : "Section header above the list of timed events on the Day tab. Uppercase in English.",
@@ -861,6 +1101,33 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "設定"
+          }
+        }
+      }
+    },
+    "Show and edit the events from your system calendars." : {
+
+    },
+    "Simple font" : {
+      "comment" : "Toggle label in Settings → Appearance: swap Instrument Serif for system sans.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Einfache Schrift"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Simple font"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "シンプルなフォント"
           }
         }
       }
@@ -961,293 +1228,8 @@
         }
       }
     },
-    "WK %lld" : {
-      "comment" : "Week count label in the Month header, e.g. 'WK 6' / 'KW 6' / '第6週'.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "KW %lld"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "WK %lld"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "第%lld週"
-          }
-        }
-      }
-    },
-    "Your events can't be loaded right now." : {
-      "comment" : "Prompt body for unexpected Calendar authorization errors.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Deine Termine können derzeit nicht geladen werden."
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Your events can't be loaded right now."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "現在、イベントを読み込めません。"
-          }
-        }
-      }
-    },
-    "A new Settings toggle swaps the serif for the system sans, for a cleaner read." : {
-      "comment" : "What's New 1.1 — Simple-font feature subtitle.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ein neuer Schalter in den Einstellungen tauscht die Serifenschrift gegen die Systemschrift – für ein klareres Schriftbild."
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "A new Settings toggle swaps the serif for the system sans, for a cleaner read."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "設定の新しいスイッチで、セリフ体をシステムのサンセリフ体に切り替えられます。読みやすさ重視のときに。"
-          }
-        }
-      }
-    },
-    "Continue" : {
-      "comment" : "What's New 1.1 — primary action that dismisses the sheet.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Weiter"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Continue"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "続ける"
-          }
-        }
-      }
-    },
-    "Deutsch & 日本語" : {
-      "comment" : "What's New 1.1 — localization feature title; kept identical across locales.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Deutsch & 日本語"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Deutsch & 日本語"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Deutsch & 日本語"
-          }
-        }
-      }
-    },
-    "Drag to reschedule" : {
-      "comment" : "What's New 1.1 — drag-to-move feature title.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ziehen zum Verschieben"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Drag to reschedule"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ドラッグで予定を移動"
-          }
-        }
-      }
-    },
-    "Events spanning several days now appear on every day they cover, across Month, Week, and Day." : {
-      "comment" : "What's New 1.1 — multi-day events feature subtitle.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Termine über mehrere Tage erscheinen jetzt an jedem betroffenen Tag – in Monat, Woche und Tag."
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Events spanning several days now appear on every day they cover, across Month, Week, and Day."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "複数日にまたがるイベントが、月・週・日のすべてで該当する各日に表示されます。"
-          }
-        }
-      }
-    },
-    "Flip the swipe" : {
-      "comment" : "What's New 1.1 — invert-swipe-direction feature title.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wischrichtung umkehren"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Flip the swipe"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "スワイプ方向を反転"
-          }
-        }
-      }
-    },
-    "Hibi now speaks German and Japanese, with locale-appropriate week-start and time format." : {
-      "comment" : "What's New 1.1 — localization feature subtitle.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hibi spricht jetzt Deutsch und Japanisch – mit passendem Wochenstart und Zeitformat."
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hibi now speaks German and Japanese, with locale-appropriate week-start and time format."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hibi がドイツ語と日本語に対応しました。週の始まりと時刻表記もロケールに合わせて切り替わります。"
-          }
-        }
-      }
-    },
-    "Long-press an event in the Week view and drop it on another day to move it." : {
-      "comment" : "What's New 1.1 — drag-to-move feature subtitle.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Halte einen Termin in der Wochenansicht gedrückt und ziehe ihn auf einen anderen Tag, um ihn zu verschieben."
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Long-press an event in the Week view and drop it on another day to move it."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "週ビューでイベントを長押しし、別の日にドロップすると移動できます。"
-          }
-        }
-      }
-    },
-    "Multi-day events" : {
-      "comment" : "What's New 1.1 — multi-day events feature title.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mehrtägige Termine"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Multi-day events"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "複数日のイベント"
-          }
-        }
-      }
-    },
-    "Prefer swipe-up to go back? Invert the Day-view tear direction in Settings." : {
-      "comment" : "What's New 1.1 — invert-swipe-direction feature subtitle.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lieber nach oben wischen, um zurückzugehen? Kehre die Abreißrichtung der Tagesansicht in den Einstellungen um."
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Prefer swipe-up to go back? Invert the Day-view tear direction in Settings."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "上方向へのスワイプで戻りたい場合は、設定で日ビューの切り取り方向を反転できます。"
-          }
-        }
-      }
+    "Welcome" : {
+
     },
     "What's New" : {
       "comment" : "Settings row + 1.1 sheet entry point. Opens the changelog.",
@@ -1293,6 +1275,54 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Hibi の新機能"
+          }
+        }
+      }
+    },
+    "WK %lld" : {
+      "comment" : "Week count label in the Month header, e.g. 'WK 6' / 'KW 6' / '第6週'.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "KW %lld"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "WK %lld"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "第%lld週"
+          }
+        }
+      }
+    },
+    "Your events can't be loaded right now." : {
+      "comment" : "Prompt body for unexpected Calendar authorization errors.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Deine Termine können derzeit nicht geladen werden."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your events can't be loaded right now."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "現在、イベントを読み込めません。"
           }
         }
       }

--- a/Hibi/Models/EventStore.swift
+++ b/Hibi/Models/EventStore.swift
@@ -129,6 +129,11 @@ final class EventStore {
         }
     }
 
+    /// Deep-link to Hibi's Settings page where the user can toggle calendar access.
+    func openCalendarSettings() {
+        Permission.calendar(access: .full).openSettingPage()
+    }
+
     // MARK: - Calendar selection
 
     /// All event calendars known to EventKit, across every account source.

--- a/Hibi/Models/EventStore.swift
+++ b/Hibi/Models/EventStore.swift
@@ -104,15 +104,26 @@ final class EventStore {
     // MARK: - Access
 
     func requestAccess() async {
-        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
-            Permission.calendar(access: .full).request {
-                continuation.resume()
-            }
+        // Use EventKit directly rather than routing through PermissionsKit:
+        // the native API returns `granted: Bool` so we update our @Observable
+        // state deterministically, without a post-request status re-query.
+        // PermissionsKit's status getter is eventually consistent after a
+        // grant; relying on it here left the UI stuck on "Allow" until the
+        // app was relaunched. PermissionsKit still drives status reads on
+        // init and scenePhase transitions, which don't have this race.
+        let granted: Bool
+        do {
+            granted = try await ekStore.requestFullAccessToEvents()
+        } catch {
+            refreshAccessStatus()
+            return
         }
-        refreshAccessStatus()
-        if hasCalendarAccess {
-            // Flush any cached unauthorized state so calendars(for:) / events(matching:)
-            // see the newly granted data without an app restart.
+        hasCalendarAccess = granted
+        calendarAccessDenied = !granted
+            && EKEventStore.authorizationStatus(for: .event) == .denied
+        if granted {
+            // Flush any cached unauthorized state so calendars(for:) /
+            // events(matching:) see the newly granted data without a restart.
             ekStore.reset()
             reloadAll()
         }

--- a/Hibi/Models/EventStore.swift
+++ b/Hibi/Models/EventStore.swift
@@ -111,6 +111,9 @@ final class EventStore {
         }
         refreshAccessStatus()
         if hasCalendarAccess {
+            // Flush any cached unauthorized state so calendars(for:) / events(matching:)
+            // see the newly granted data without an app restart.
+            ekStore.reset()
             reloadAll()
         }
     }
@@ -118,8 +121,10 @@ final class EventStore {
     /// Re-check the system permission on the next run loop tick. Call after the app
     /// returns to the foreground — users may have flipped the toggle in Settings.
     func refreshAccessFromScenePhase() {
+        let wasAuthorized = hasCalendarAccess
         refreshAccessStatus()
         if hasCalendarAccess {
+            if !wasAuthorized { ekStore.reset() }
             reloadAll()
         }
     }

--- a/Hibi/Models/EventStore.swift
+++ b/Hibi/Models/EventStore.swift
@@ -1,13 +1,16 @@
+import CalendarPermission
 import EventKit
 import Foundation
 import Observation
+import PermissionsKit
 import SwiftUI
 
 @MainActor
 @Observable
 final class EventStore {
     let ekStore = EKEventStore()
-    private(set) var authorization: EKAuthorizationStatus
+    private(set) var hasCalendarAccess: Bool
+    private(set) var calendarAccessDenied: Bool
     /// Debug demo mode: fixture data only, persisted. Release UI toggle is `#if DEBUG` only.
     private(set) var isDemoMode: Bool
     private(set) var eventsByMonth: [MonthKey: [Int: [CalendarEvent]]] = [:]
@@ -18,9 +21,9 @@ final class EventStore {
     private static let hiddenIDsDefaultsKey = "hiddenCalendarIDs"
     private static let demoModeDefaultsKey = "demoMode"
 
-    /// Month/stream/day views use this instead of checking `authorization` alone so demo works without EventKit.
+    /// Month/stream/day views use this instead of checking access alone so demo works without EventKit.
     var showsCalendarContent: Bool {
-        isDemoMode || authorization == .fullAccess
+        isDemoMode || hasCalendarAccess
     }
 
     private let calendar: Calendar = {
@@ -38,7 +41,9 @@ final class EventStore {
     }()
 
     init() {
-        self.authorization = EKEventStore.authorizationStatus(for: .event)
+        let permission = Permission.calendar(access: .full)
+        self.hasCalendarAccess = permission.authorized
+        self.calendarAccessDenied = permission.denied
         #if DEBUG
         self.isDemoMode = UserDefaults.standard.bool(forKey: Self.demoModeDefaultsKey)
         #else
@@ -56,9 +61,16 @@ final class EventStore {
             queue: .main
         ) { [weak self] _ in
             Task { @MainActor [weak self] in
+                self?.refreshAccessStatus()
                 self?.reloadAll()
             }
         }
+    }
+
+    private func refreshAccessStatus() {
+        let permission = Permission.calendar(access: .full)
+        hasCalendarAccess = permission.authorized
+        calendarAccessDenied = permission.denied
     }
 
     func setDemoMode(_ enabled: Bool) {
@@ -92,14 +104,23 @@ final class EventStore {
     // MARK: - Access
 
     func requestAccess() async {
-        do {
-            let granted = try await ekStore.requestFullAccessToEvents()
-            authorization = EKEventStore.authorizationStatus(for: .event)
-            if granted {
-                reloadAll()
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            Permission.calendar(access: .full).request {
+                continuation.resume()
             }
-        } catch {
-            authorization = EKEventStore.authorizationStatus(for: .event)
+        }
+        refreshAccessStatus()
+        if hasCalendarAccess {
+            reloadAll()
+        }
+    }
+
+    /// Re-check the system permission on the next run loop tick. Call after the app
+    /// returns to the foreground — users may have flipped the toggle in Settings.
+    func refreshAccessFromScenePhase() {
+        refreshAccessStatus()
+        if hasCalendarAccess {
+            reloadAll()
         }
     }
 
@@ -108,7 +129,7 @@ final class EventStore {
     /// All event calendars known to EventKit, across every account source.
     func allCalendars() -> [EKCalendar] {
         guard !isDemoMode else { return [] }
-        guard authorization == .fullAccess else { return [] }
+        guard hasCalendarAccess else { return [] }
         return ekStore.calendars(for: .event)
     }
 
@@ -142,7 +163,7 @@ final class EventStore {
 
     func reload(year: Int, month: Int) {
         guard !isDemoMode else { return }
-        guard authorization == .fullAccess else { return }
+        guard hasCalendarAccess else { return }
         let key = MonthKey(year: year, month: month)
 
         var comps = DateComponents(year: year, month: month, day: 1)
@@ -234,7 +255,7 @@ final class EventStore {
         to: (year: Int, month: Int, day: Int)
     ) -> Bool {
         guard !isDemoMode else { return false }
-        guard authorization == .fullAccess else { return false }
+        guard hasCalendarAccess else { return false }
         guard let ek = ekStore.event(withIdentifier: identifier) else { return false }
 
         guard

--- a/Hibi/Models/WeatherStore.swift
+++ b/Hibi/Models/WeatherStore.swift
@@ -11,6 +11,7 @@ import WeatherKit
 @Observable
 final class WeatherStore: NSObject {
     private(set) var hasLocationAccess: Bool
+    private(set) var locationAccessDenied: Bool
     private(set) var locationName: String?
 
     private var weatherByDay: [DayKey: DayWeather] = [:]
@@ -35,7 +36,9 @@ final class WeatherStore: NSObject {
     }
 
     override init() {
-        self.hasLocationAccess = Permission.location(access: .whenInUse).authorized
+        let permission = Permission.location(access: .whenInUse)
+        self.hasLocationAccess = permission.authorized
+        self.locationAccessDenied = permission.denied
         super.init()
         manager.delegate = self
         manager.desiredAccuracy = kCLLocationAccuracyKilometer
@@ -43,18 +46,22 @@ final class WeatherStore: NSObject {
 
     // MARK: - Access
 
-    func requestAccess() {
+    func requestAccess() async {
         let permission = Permission.location(access: .whenInUse)
         guard permission.notDetermined else { return }
-        permission.request {
-            // PermissionsKit calls completion on the main thread, but it's typed
-            // as non-isolated. Hop to the MainActor so we can touch store state.
-            Task { @MainActor [weak self] in
-                guard let self else { return }
-                self.hasLocationAccess = permission.authorized
-                if self.hasLocationAccess { self.refresh() }
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            permission.request {
+                continuation.resume()
             }
         }
+        hasLocationAccess = permission.authorized
+        locationAccessDenied = permission.denied
+        if hasLocationAccess { refresh() }
+    }
+
+    /// Deep-link to Hibi's Settings page where the user can toggle location access.
+    func openLocationSettings() {
+        Permission.location(access: .whenInUse).openSettingPage()
     }
 
     // MARK: - Query
@@ -160,7 +167,9 @@ extension WeatherStore: CLLocationManagerDelegate {
     nonisolated func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
         Task { @MainActor [weak self] in
             guard let self else { return }
-            self.hasLocationAccess = Permission.location(access: .whenInUse).authorized
+            let permission = Permission.location(access: .whenInUse)
+            self.hasLocationAccess = permission.authorized
+            self.locationAccessDenied = permission.denied
             if self.hasLocationAccess {
                 self.refresh()
             }

--- a/Hibi/Models/WeatherStore.swift
+++ b/Hibi/Models/WeatherStore.swift
@@ -1,14 +1,16 @@
 import CoreLocation
 import Foundation
+import LocationPermission
 import MapKit
 import Observation
 import OSLog
+import PermissionsKit
 import WeatherKit
 
 @MainActor
 @Observable
 final class WeatherStore: NSObject {
-    private(set) var authorizationStatus: CLAuthorizationStatus
+    private(set) var hasLocationAccess: Bool
     private(set) var locationName: String?
 
     private var weatherByDay: [DayKey: DayWeather] = [:]
@@ -33,7 +35,7 @@ final class WeatherStore: NSObject {
     }
 
     override init() {
-        self.authorizationStatus = manager.authorizationStatus
+        self.hasLocationAccess = Permission.location(access: .whenInUse).authorized
         super.init()
         manager.delegate = self
         manager.desiredAccuracy = kCLLocationAccuracyKilometer
@@ -42,8 +44,17 @@ final class WeatherStore: NSObject {
     // MARK: - Access
 
     func requestAccess() {
-        guard authorizationStatus == .notDetermined else { return }
-        manager.requestWhenInUseAuthorization()
+        let permission = Permission.location(access: .whenInUse)
+        guard permission.notDetermined else { return }
+        permission.request {
+            // PermissionsKit calls completion on the main thread, but it's typed
+            // as non-isolated. Hop to the MainActor so we can touch store state.
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                self.hasLocationAccess = permission.authorized
+                if self.hasLocationAccess { self.refresh() }
+            }
+        }
     }
 
     // MARK: - Query
@@ -57,9 +68,7 @@ final class WeatherStore: NSObject {
     /// Fetches a fresh location + weather if the cache is stale.
     /// Safe to call repeatedly — self-throttles.
     func refresh() {
-        guard authorizationStatus == .authorizedWhenInUse || authorizationStatus == .authorizedAlways else {
-            return
-        }
+        guard hasLocationAccess else { return }
         if let last = lastFetchAt, Date().timeIntervalSince(last) < 30 * 60 {
             return
         }
@@ -149,11 +158,10 @@ final class WeatherStore: NSObject {
 
 extension WeatherStore: CLLocationManagerDelegate {
     nonisolated func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
-        let status = manager.authorizationStatus
         Task { @MainActor [weak self] in
             guard let self else { return }
-            self.authorizationStatus = status
-            if status == .authorizedWhenInUse || status == .authorizedAlways {
+            self.hasLocationAccess = Permission.location(access: .whenInUse).authorized
+            if self.hasLocationAccess {
                 self.refresh()
             }
         }

--- a/Hibi/Views/CalendarSelectionView.swift
+++ b/Hibi/Views/CalendarSelectionView.swift
@@ -9,10 +9,10 @@ struct CalendarSelectionView: View {
 
     var body: some View {
         Group {
-            if eventStore.authorization == .fullAccess || eventStore.isDemoMode {
+            if eventStore.hasCalendarAccess || eventStore.isDemoMode {
                 content
             } else {
-                CalendarAccessPrompt(status: eventStore.authorization) {
+                CalendarAccessPrompt(isDenied: eventStore.calendarAccessDenied) {
                     Task { await eventStore.requestAccess() }
                 }
             }

--- a/Hibi/Views/Components/CalendarAccessPrompt.swift
+++ b/Hibi/Views/Components/CalendarAccessPrompt.swift
@@ -1,9 +1,9 @@
-import EventKit
+import CalendarPermission
+import PermissionsKit
 import SwiftUI
-import UIKit
 
 struct CalendarAccessPrompt: View {
-    let status: EKAuthorizationStatus
+    let isDenied: Bool
     let onRequestAccess: () -> Void
 
     var body: some View {
@@ -19,13 +19,10 @@ struct CalendarAccessPrompt: View {
                 .foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)
             Button {
-                switch status {
-                case .notDetermined:
+                if isDenied {
+                    Permission.calendar(access: .full).openSettingPage()
+                } else {
                     onRequestAccess()
-                default:
-                    if let url = URL(string: UIApplication.openSettingsURLString) {
-                        UIApplication.shared.open(url)
-                    }
                 }
             } label: {
                 Text(buttonLabel)
@@ -38,24 +35,16 @@ struct CalendarAccessPrompt: View {
     }
 
     private var title: LocalizedStringResource {
-        switch status {
-        case .notDetermined: "Calendar access needed"
-        case .denied, .restricted: "Calendar access denied"
-        case .writeOnly: "Full calendar access needed"
-        default: "Calendar unavailable"
-        }
+        isDenied ? "Calendar access denied" : "Calendar access needed"
     }
 
     private var message: LocalizedStringResource {
-        switch status {
-        case .notDetermined: "Grant access to see and edit your events."
-        case .denied, .restricted: "Enable calendar access in Settings to see your events."
-        case .writeOnly: "Enable full calendar access in Settings to see your events."
-        default: "Your events can't be loaded right now."
-        }
+        isDenied
+            ? "Enable full calendar access in Settings to see your events."
+            : "Grant access to see and edit your events."
     }
 
     private var buttonLabel: LocalizedStringResource {
-        status == .notDetermined ? "Grant access" : "Open Settings"
+        isDenied ? "Open Settings" : "Grant access"
     }
 }

--- a/Hibi/Views/Components/PermissionsOnboardingSheet.swift
+++ b/Hibi/Views/Components/PermissionsOnboardingSheet.swift
@@ -11,6 +11,9 @@ struct PermissionOnboardingItem: Identifiable {
     let tint: Color
     let title: LocalizedStringResource
     let description: LocalizedStringResource
+    /// Required permissions gate the "Continue" button — the user can't finish
+    /// onboarding without granting them. Optional permissions can be skipped.
+    let isRequired: Bool
     let isGranted: @MainActor () -> Bool
     let isDenied: @MainActor () -> Bool
     let request: @MainActor () async -> Void
@@ -63,6 +66,7 @@ struct PermissionsOnboardingSheet: View {
             .buttonStyle(.borderedProminent)
             .tint(.primary)
             .foregroundStyle(Color(.systemBackground))
+            .disabled(!canContinue)
             .padding(.horizontal, 28)
             .padding(.bottom, 20)
             .frame(maxWidth: 460)
@@ -78,6 +82,13 @@ struct PermissionsOnboardingSheet: View {
             AppBackgroundGradient().ignoresSafeArea()
         }
         .onAppear { appeared = true }
+    }
+
+    /// Continue is disabled until every required permission is granted.
+    /// Computed each render — `isGranted()` is a light wrapper over PermissionsKit's
+    /// system status query, which re-evaluates against the live authorization state.
+    private var canContinue: Bool {
+        items.filter(\.isRequired).allSatisfy { $0.isGranted() }
     }
 
     private var header: some View {
@@ -97,6 +108,7 @@ struct PermissionsOnboardingSheet: View {
 
 private struct PermissionRow: View {
     let item: PermissionOnboardingItem
+    @State private var isRequesting = false
 
     var body: some View {
         HStack(spacing: 14) {
@@ -150,6 +162,10 @@ private struct PermissionRow: View {
                     .font(.system(size: 26, weight: .regular))
                     .foregroundStyle(Color.green.gradient)
                     .transition(.scale(scale: 0.6).combined(with: .opacity))
+            } else if isRequesting {
+                ProgressView()
+                    .controlSize(.small)
+                    .transition(.opacity)
             } else if denied {
                 Button {
                     item.openSettings()
@@ -164,10 +180,13 @@ private struct PermissionRow: View {
             } else {
                 Button {
                     Task { @MainActor in
+                        isRequesting = true
                         await item.request()
-                        // The store mutation that flips isGranted happens inside
-                        // request(); SwiftUI re-evaluates trailing and fires the
-                        // checkmark transition.
+                        // isGranted flips inside request(); SwiftUI re-evaluates
+                        // and the checkmark transitions in. Clear the requesting
+                        // flag last so the row never shows both the spinner and
+                        // the stale Allow button at the same time.
+                        isRequesting = false
                     }
                 } label: {
                     Text("Allow")
@@ -182,6 +201,7 @@ private struct PermissionRow: View {
         }
         .animation(.spring(response: 0.4, dampingFraction: 0.7), value: granted)
         .animation(.easeInOut(duration: 0.2), value: denied)
+        .animation(.easeInOut(duration: 0.15), value: isRequesting)
     }
 }
 
@@ -196,6 +216,7 @@ private struct PermissionRow: View {
                 tint: Color(.displayP3, red: 0.78, green: 0.49, blue: 0.42, opacity: 1),
                 title: "Calendar",
                 description: "Show and edit the events from your system calendars.",
+                isRequired: true,
                 isGranted: { false },
                 isDenied: { false },
                 request: { },
@@ -207,6 +228,7 @@ private struct PermissionRow: View {
                 tint: Color(.displayP3, red: 0.38, green: 0.55, blue: 0.76, opacity: 1),
                 title: "Location",
                 description: "Local weather and sunrise / sunset on each day.",
+                isRequired: false,
                 isGranted: { false },
                 isDenied: { false },
                 request: { },

--- a/Hibi/Views/Components/PermissionsOnboardingSheet.swift
+++ b/Hibi/Views/Components/PermissionsOnboardingSheet.swift
@@ -27,6 +27,13 @@ struct PermissionsOnboardingSheet: View {
     let onContinue: () -> Void
 
     @State private var appeared = false
+    /// Snapshotted once on first appearance. Prevents auto-dismiss from firing
+    /// when the sheet is re-opened from Settings while everything is already
+    /// granted — auto-dismiss should only celebrate a fresh completion.
+    @State private var startedWithAllGranted = true
+    /// Brief success state shown between the last grant and the actual dismiss,
+    /// so the user sees confirmation instead of the sheet just yanking away.
+    @State private var isCelebrating = false
     @AppStorage("useSimpleFont") private var useSimpleFont: Bool = false
     @Environment(\.dismiss) private var dismiss
 
@@ -58,14 +65,18 @@ struct PermissionsOnboardingSheet: View {
                 onContinue()
                 dismiss()
             } label: {
-                Text("Continue")
+                continueLabel
                     .font(.system(size: 16, weight: .semibold))
                     .frame(maxWidth: .infinity)
                     .padding(.vertical, 14)
             }
             .buttonStyle(.borderedProminent)
-            .tint(.primary)
-            .foregroundStyle(Color(.systemBackground))
+            .tint(isCelebrating ? Color.green : .primary)
+            // In the normal state the tint is `.primary` (black/white depending
+            // on appearance) so the label needs the inverse for contrast.
+            // During celebration the tint is green, and white reads on green
+            // in both light and dark.
+            .foregroundStyle(isCelebrating ? Color.white : Color(.systemBackground))
             .disabled(!canContinue)
             .padding(.horizontal, 28)
             .padding(.bottom, 20)
@@ -76,12 +87,43 @@ struct PermissionsOnboardingSheet: View {
                     .delay(0.18 + Double(items.count) * 0.08 + 0.05),
                 value: appeared
             )
+            .animation(.spring(response: 0.4, dampingFraction: 0.75), value: isCelebrating)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .presentationBackground {
             AppBackgroundGradient().ignoresSafeArea()
         }
-        .onAppear { appeared = true }
+        .onAppear {
+            appeared = true
+            startedWithAllGranted = allGranted
+        }
+        .onChange(of: allGranted) { _, newValue in
+            // Auto-dismiss only when the user just completed the final grant
+            // in THIS session. If the sheet was opened (e.g. from Settings)
+            // with everything already granted, don't yank it away — the user
+            // came here on purpose.
+            guard newValue, !startedWithAllGranted, !isCelebrating else { return }
+            isCelebrating = true
+            Task { @MainActor in
+                try? await Task.sleep(for: .milliseconds(900))
+                onContinue()
+                dismiss()
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var continueLabel: some View {
+        if isCelebrating {
+            HStack(spacing: 8) {
+                Image(systemName: "checkmark")
+                Text("All set")
+            }
+            .transition(.scale(scale: 0.85).combined(with: .opacity))
+        } else {
+            Text("Continue")
+                .transition(.opacity)
+        }
     }
 
     /// Continue is disabled until every required permission is granted.
@@ -89,6 +131,12 @@ struct PermissionsOnboardingSheet: View {
     /// system status query, which re-evaluates against the live authorization state.
     private var canContinue: Bool {
         items.filter(\.isRequired).allSatisfy { $0.isGranted() }
+    }
+
+    /// True when every row (required + optional) is granted — the cue for
+    /// auto-dismiss.
+    private var allGranted: Bool {
+        items.allSatisfy { $0.isGranted() }
     }
 
     private var header: some View {

--- a/Hibi/Views/Components/PermissionsOnboardingSheet.swift
+++ b/Hibi/Views/Components/PermissionsOnboardingSheet.swift
@@ -1,0 +1,218 @@
+import SwiftUI
+
+// MARK: - Item
+
+/// One permission entry rendered in the onboarding sheet. Platform-agnostic
+/// (no UIKit/EventKit) so macOS/iPadOS builds and additional permissions —
+/// Notifications, Contacts, Reminders — can append rows without view changes.
+struct PermissionOnboardingItem: Identifiable {
+    let id: String
+    let icon: String
+    let tint: Color
+    let title: LocalizedStringResource
+    let description: LocalizedStringResource
+    let isGranted: @MainActor () -> Bool
+    let isDenied: @MainActor () -> Bool
+    let request: @MainActor () async -> Void
+    let openSettings: @MainActor () -> Void
+}
+
+// MARK: - Sheet
+
+struct PermissionsOnboardingSheet: View {
+    let items: [PermissionOnboardingItem]
+    let onContinue: () -> Void
+
+    @State private var appeared = false
+    @AppStorage("useSimpleFont") private var useSimpleFont: Bool = false
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+                .padding(.top, 32)
+                .padding(.horizontal, 28)
+
+            VStack(spacing: 12) {
+                ForEach(Array(items.enumerated()), id: \.element.id) { index, item in
+                    PermissionRow(item: item)
+                        .opacity(appeared ? 1 : 0)
+                        .offset(y: appeared ? 0 : 14)
+                        .animation(
+                            .spring(response: 0.45, dampingFraction: 0.85)
+                                .delay(0.18 + Double(index) * 0.08),
+                            value: appeared
+                        )
+                }
+            }
+            .padding(.horizontal, 20)
+            .padding(.top, 28)
+            .frame(maxWidth: 460)
+
+            Spacer(minLength: 24)
+
+            Button {
+                onContinue()
+                dismiss()
+            } label: {
+                Text("Continue")
+                    .font(.system(size: 16, weight: .semibold))
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 14)
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(.primary)
+            .foregroundStyle(Color(.systemBackground))
+            .padding(.horizontal, 28)
+            .padding(.bottom, 20)
+            .frame(maxWidth: 460)
+            .opacity(appeared ? 1 : 0)
+            .animation(
+                .easeOut(duration: 0.35)
+                    .delay(0.18 + Double(items.count) * 0.08 + 0.05),
+                value: appeared
+            )
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .presentationBackground {
+            AppBackgroundGradient().ignoresSafeArea()
+        }
+        .onAppear { appeared = true }
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Welcome")
+                .font(.appSerif(size: 34, italic: true, simple: useSimpleFont))
+                .foregroundStyle(.primary)
+            Text("A couple of permissions so Hibi can do its thing.")
+                .font(.appSerif(size: 16, italic: true, simple: useSimpleFont))
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+// MARK: - Row
+
+private struct PermissionRow: View {
+    let item: PermissionOnboardingItem
+
+    var body: some View {
+        HStack(spacing: 14) {
+            iconBadge
+            VStack(alignment: .leading, spacing: 3) {
+                Text(item.title)
+                    .font(.system(size: 15, weight: .semibold))
+                    .foregroundStyle(.primary)
+                Text(item.description)
+                    .font(.system(size: 13))
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            trailing
+                .frame(minWidth: 64)
+        }
+        .padding(14)
+        .background(
+            RoundedRectangle(cornerRadius: 18, style: .continuous)
+                .fill(PaperTints.card1)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 18, style: .continuous)
+                .stroke(Color.primary.opacity(0.06), lineWidth: 0.5)
+        )
+        .shadow(color: .black.opacity(0.06), radius: 10, x: 0, y: 4)
+    }
+
+    private var iconBadge: some View {
+        ZStack {
+            Circle()
+                .fill(item.tint)
+                .frame(width: 36, height: 36)
+            Image(systemName: item.icon)
+                .font(.system(size: 16, weight: .medium))
+                .foregroundStyle(.white)
+        }
+    }
+
+    @ViewBuilder
+    private var trailing: some View {
+        // Recompute on every render — PermissionsKit reads system status, cheap.
+        let granted = item.isGranted()
+        let denied = item.isDenied()
+
+        Group {
+            if granted {
+                Image(systemName: "checkmark.circle.fill")
+                    .font(.system(size: 26, weight: .regular))
+                    .foregroundStyle(Color.green.gradient)
+                    .transition(.scale(scale: 0.6).combined(with: .opacity))
+            } else if denied {
+                Button {
+                    item.openSettings()
+                } label: {
+                    Text("Settings")
+                        .font(.system(size: 13, weight: .semibold))
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 7)
+                }
+                .buttonStyle(.bordered)
+                .tint(.primary)
+            } else {
+                Button {
+                    Task { @MainActor in
+                        await item.request()
+                        // The store mutation that flips isGranted happens inside
+                        // request(); SwiftUI re-evaluates trailing and fires the
+                        // checkmark transition.
+                    }
+                } label: {
+                    Text("Allow")
+                        .font(.system(size: 13, weight: .semibold))
+                        .padding(.horizontal, 14)
+                        .padding(.vertical, 7)
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(.primary)
+                .foregroundStyle(Color(.systemBackground))
+            }
+        }
+        .animation(.spring(response: 0.4, dampingFraction: 0.7), value: granted)
+        .animation(.easeInOut(duration: 0.2), value: denied)
+    }
+}
+
+// MARK: - Preview
+
+#Preview("Onboarding") {
+    PermissionsOnboardingSheet(
+        items: [
+            PermissionOnboardingItem(
+                id: "calendar",
+                icon: "calendar",
+                tint: Color(.displayP3, red: 0.78, green: 0.49, blue: 0.42, opacity: 1),
+                title: "Calendar",
+                description: "Show and edit the events from your system calendars.",
+                isGranted: { false },
+                isDenied: { false },
+                request: { },
+                openSettings: { }
+            ),
+            PermissionOnboardingItem(
+                id: "location",
+                icon: "location.fill",
+                tint: Color(.displayP3, red: 0.38, green: 0.55, blue: 0.76, opacity: 1),
+                title: "Location",
+                description: "Local weather and sunrise / sunset on each day.",
+                isGranted: { false },
+                isDenied: { false },
+                request: { },
+                openSettings: { }
+            ),
+        ],
+        onContinue: { }
+    )
+}

--- a/Hibi/Views/DayView.swift
+++ b/Hibi/Views/DayView.swift
@@ -299,7 +299,7 @@ struct DayView: View {
         let events = eventStore.events(year: year, month: month, day: scheduleDay)
         return Group {
             if !eventStore.showsCalendarContent {
-                CalendarAccessPrompt(status: eventStore.authorization) {
+                CalendarAccessPrompt(isDenied: eventStore.calendarAccessDenied) {
                     Task { await eventStore.requestAccess() }
                 }
             } else if events.isEmpty {

--- a/Hibi/Views/PaperTints.swift
+++ b/Hibi/Views/PaperTints.swift
@@ -72,3 +72,35 @@ extension Color {
         })
     }
 }
+
+/// Shared app canvas — cream radial in light, near-black radial in dark.
+/// Single source of truth used by `ContentView` and the onboarding sheet so
+/// the sheet reads as a continuation of the app surface, not system chrome.
+struct AppBackgroundGradient: View {
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        if colorScheme == .dark {
+            RadialGradient(
+                colors: [
+                    Color(.displayP3, red: 0.102, green: 0.102, blue: 0.122),
+                    Color(.displayP3, red: 0.047, green: 0.047, blue: 0.055),
+                ],
+                center: UnitPoint(x: 0.2, y: 0.0),
+                startRadius: 0,
+                endRadius: 600
+            )
+        } else {
+            RadialGradient(
+                colors: [
+                    Color(.displayP3, red: 0.984, green: 0.980, blue: 0.965),
+                    Color(.displayP3, red: 0.953, green: 0.945, blue: 0.918),
+                    Color(.displayP3, red: 0.929, green: 0.914, blue: 0.867),
+                ],
+                center: UnitPoint(x: 0.15, y: -0.1),
+                startRadius: 0,
+                endRadius: 700
+            )
+        }
+    }
+}

--- a/Hibi/Views/SettingsView.swift
+++ b/Hibi/Views/SettingsView.swift
@@ -3,8 +3,13 @@ import SwiftUI
 import WhatsNewKit
 
 struct SettingsView: View {
+    /// Called by the "Review permissions" button. ContentView latches this and
+    /// presents the onboarding sheet once Settings dismisses (can't stack sheets).
+    let onReopenPermissions: () -> Void
+
     @Environment(\.dismiss) private var dismiss
     @Environment(EventStore.self) private var eventStore
+    @Environment(WeatherStore.self) private var weatherStore
     @AppStorage("appearance") private var appearanceRaw: String = Appearance.system.rawValue
     @AppStorage("invertDaySwipe") private var invertDaySwipe: Bool = false
     @AppStorage("useSimpleFont") private var useSimpleFont: Bool = false
@@ -53,6 +58,22 @@ struct SettingsView: View {
                     }
                 }
 
+                if hasMissingPermission {
+                    Section("Permissions") {
+                        Button {
+                            onReopenPermissions()
+                            dismiss()
+                        } label: {
+                            LabeledContent("Review permissions") {
+                                Image(systemName: "chevron.right")
+                                    .font(.system(size: 13, weight: .semibold))
+                                    .foregroundStyle(.tertiary)
+                            }
+                        }
+                        .tint(.primary)
+                    }
+                }
+
                 #if DEBUG
                 Section("Debug") {
                     Toggle("Demo Mode", isOn: Binding(
@@ -95,5 +116,9 @@ struct SettingsView: View {
         let all = eventStore.allCalendars()
         let visible = all.filter { !eventStore.isHidden($0) }.count
         return "\(visible) / \(all.count)"
+    }
+
+    private var hasMissingPermission: Bool {
+        !eventStore.hasCalendarAccess || !weatherStore.hasLocationAccess
     }
 }

--- a/Hibi/Views/SettingsView.swift
+++ b/Hibi/Views/SettingsView.swift
@@ -91,7 +91,7 @@ struct SettingsView: View {
 
     private var calendarSummary: LocalizedStringResource {
         if eventStore.isDemoMode { return "Demo" }
-        guard eventStore.authorization == .fullAccess else { return "Not connected" }
+        guard eventStore.hasCalendarAccess else { return "Not connected" }
         let all = eventStore.allCalendars()
         let visible = all.filter { !eventStore.isHidden($0) }.count
         return "\(visible) / \(all.count)"

--- a/Hibi/Views/StreamView.swift
+++ b/Hibi/Views/StreamView.swift
@@ -54,7 +54,7 @@ struct StreamView: View {
     var body: some View {
         ScrollView {
             if !eventStore.showsCalendarContent {
-                CalendarAccessPrompt(status: eventStore.authorization) {
+                CalendarAccessPrompt(isDenied: eventStore.calendarAccessDenied) {
                     Task { await eventStore.requestAccess() }
                 }
                 .padding(.horizontal, 20)


### PR DESCRIPTION
Adds sparrowcode/PermissionsKit 11.1.0 (CalendarPermission +
LocationPermission products) and rewrites the request + status paths
to use its unified API. EventStore exposes hasCalendarAccess /
calendarAccessDenied; WeatherStore exposes hasLocationAccess. The
CalendarAccessPrompt collapses to two states (request vs open Settings)
and uses Permission.openSettingPage() instead of the hand-rolled
UIApplication.openSettingsURLString path.

https://claude.ai/code/session_01RwwjAoy2ArGe3Vy8ismHwR