### PR TITLE
add temperature unit + time format settings

### DIFF
--- a/Hibi/ContentView.swift
+++ b/Hibi/ContentView.swift
@@ -240,6 +240,11 @@ struct ContentView: View {
 private struct SearchResultsView: View {
     let query: String
     @Environment(EventStore.self) private var eventStore
+    @AppStorage(TimeFormat.defaultsKey) private var timeFormatRaw: String = TimeFormat.system.rawValue
+
+    private var timeFormat: TimeFormat {
+        TimeFormat(rawValue: timeFormatRaw) ?? .system
+    }
 
     var body: some View {
         let matches: [(year: Int, month: Int, event: CalendarEvent)] = {
@@ -285,7 +290,9 @@ private struct SearchResultsView: View {
         if item.event.allDay {
             return "\(date) · \(String(localized: "All day"))"
         }
-        let time = "\(item.event.start ?? "")–\(item.event.end ?? "")"
+        let start = item.event.startDate.map { timeFormat.string(from: $0) } ?? ""
+        let end = item.event.endDate.map { timeFormat.string(from: $0) } ?? ""
+        let time = "\(start)–\(end)"
         if let loc = item.event.location {
             return "\(date) · \(time) · \(loc)"
         }

--- a/Hibi/Models/CalendarEvent.swift
+++ b/Hibi/Models/CalendarEvent.swift
@@ -20,10 +20,8 @@ struct CalendarEvent: Identifiable, Hashable {
     let id: String
     let eventIdentifier: String?
     let day: Int
-    let start: String?
-    let end: String?
-    /// Absolute start/end — kept separate from the HH:mm strings so progress
-    /// computation works for events that span into another day.
+    /// Absolute start/end — views format against the user's time-format
+    /// preference at render time (see `TimeFormat`).
     let startDate: Date?
     let endDate: Date?
     let title: String
@@ -36,8 +34,6 @@ struct CalendarEvent: Identifiable, Hashable {
     init(id: String = UUID().uuidString,
          eventIdentifier: String? = nil,
          day: Int,
-         start: String? = nil,
-         end: String? = nil,
          startDate: Date? = nil,
          endDate: Date? = nil,
          title: String,
@@ -47,8 +43,6 @@ struct CalendarEvent: Identifiable, Hashable {
         self.id = id
         self.eventIdentifier = eventIdentifier
         self.day = day
-        self.start = start
-        self.end = end
         self.startDate = startDate
         self.endDate = endDate
         self.title = title
@@ -98,8 +92,11 @@ extension CalendarEvent {
 }
 
 struct DayWeather: Hashable {
-    let high: Int
-    let low: Int
+    /// Stored in Celsius with full decimal precision. Views convert + round
+    /// at display time so switching the temperature unit doesn't accumulate
+    /// rounding error (e.g. 23.4°C → 23 → 73°F instead of the correct 74°F).
+    let high: Double
+    let low: Double
     let code: WeatherCode
     let sunrise: Date?
     let sunset: Date?

--- a/Hibi/Models/DemoFixtures.swift
+++ b/Hibi/Models/DemoFixtures.swift
@@ -7,21 +7,10 @@ import SwiftUI
 /// except **April 18** (SampleData “today”) stays full for screenshots. **Smart Cities Expo**
 /// runs Apr 10–11 only so Apr 12 is a quiet gap after the conference.
 enum DemoFixtures {
-    private static let timeFormatter: DateFormatter = {
-        let f = DateFormatter()
-        f.locale = Locale(identifier: "en_US_POSIX")
-        f.dateFormat = "HH:mm"
-        return f
-    }()
-
     private static func d(_ y: Int, _ m: Int, _ day: Int, h: Int = 0, min: Int = 0) -> Date {
         var comps = DateComponents(year: y, month: m, day: day, hour: h, minute: min)
         comps.calendar = Calendar(identifier: .gregorian)
         return comps.date!
-    }
-
-    private static func t(_ start: Date, _ end: Date) -> (String, String) {
-        (timeFormatter.string(from: start), timeFormatter.string(from: end))
     }
 
     static let events: [MonthKey: [Int: [CalendarEvent]]] = makeEvents()
@@ -44,13 +33,10 @@ enum DemoFixtures {
         ) {
             let s = d(y, m, day, h: h1, min: m1)
             let e = d(y, m, day, h: h2, min: m2)
-            let pair = t(s, e)
             add(y, m, day, CalendarEvent(
                 id: id,
                 eventIdentifier: nil,
                 day: day,
-                start: pair.0,
-                end: pair.1,
                 startDate: s,
                 endDate: e,
                 title: title,
@@ -66,7 +52,7 @@ enum DemoFixtures {
                 for dayKey in sortedDays.keys {
                     sortedDays[dayKey]?.sort { lhs, rhs in
                         if lhs.allDay != rhs.allDay { return lhs.allDay && !rhs.allDay }
-                        return (lhs.start ?? "") < (rhs.start ?? "")
+                        return (lhs.startDate ?? .distantPast) < (rhs.startDate ?? .distantPast)
                     }
                 }
                 out[key] = sortedDays
@@ -102,13 +88,10 @@ enum DemoFixtures {
         addTimed("demo-feb-112", 2026, 2, 13, 17, 30, 18, 30, title: "Therapy session", tint: sky)
         let feb14s = d(2026, 2, 14, h: 10, min: 0)
         let feb14e = d(2026, 2, 14, h: 12, min: 30)
-        let feb14t = t(feb14s, feb14e)
         add(2026, 2, 14, CalendarEvent(
             id: "demo-feb-002",
             eventIdentifier: nil,
             day: 14,
-            start: feb14t.0,
-            end: feb14t.1,
             startDate: feb14s,
             endDate: feb14e,
             title: "Valentine’s brunch",
@@ -154,13 +137,10 @@ enum DemoFixtures {
         addTimed("demo-mar-107", 2026, 3, 7, 11, 0, 12, 30, title: "Brunch with parents", tint: rose, location: "The Orchard")
         let mar8s = d(2026, 3, 8, h: 11, min: 0)
         let mar8e = d(2026, 3, 8, h: 13, min: 0)
-        let mar8t = t(mar8s, mar8e)
         add(2026, 3, 8, CalendarEvent(
             id: "demo-mar-001",
             eventIdentifier: nil,
             day: 8,
-            start: mar8t.0,
-            end: mar8t.1,
             startDate: mar8s,
             endDate: mar8e,
             title: "Women’s Day — family coffee",
@@ -177,13 +157,10 @@ enum DemoFixtures {
         addTimed("demo-mar-114b", 2026, 3, 14, 15, 0, 16, 30, title: "Nap + laundry", tint: butter)
         let mar15s = d(2026, 3, 15, h: 15, min: 30)
         let mar15e = d(2026, 3, 15, h: 16, min: 30)
-        let mar15t = t(mar15s, mar15e)
         add(2026, 3, 15, CalendarEvent(
             id: "demo-mar-002",
             eventIdentifier: nil,
             day: 15,
-            start: mar15t.0,
-            end: mar15t.1,
             startDate: mar15s,
             endDate: mar15e,
             title: "Dentist checkup",
@@ -217,13 +194,10 @@ enum DemoFixtures {
         addTimed("demo-apr-103", 2026, 4, 2, 15, 30, 16, 30, title: "Tea with neighbor", tint: peach, location: "Patio")
         let apr3s = d(2026, 4, 3, h: 10, min: 0)
         let apr3e = d(2026, 4, 3, h: 11, min: 30)
-        let apr3t = t(apr3s, apr3e)
         add(2026, 4, 3, CalendarEvent(
             id: "demo-apr-001",
             eventIdentifier: nil,
             day: 3,
-            start: apr3t.0,
-            end: apr3t.1,
             startDate: apr3s,
             endDate: apr3e,
             title: "Team stand-up & roadmap",
@@ -236,13 +210,10 @@ enum DemoFixtures {
         addTimed("demo-apr-104b", 2026, 4, 4, 16, 0, 17, 30, title: "Egg hunt — neighborhood", tint: mint, location: "Park")
         let apr5s = d(2026, 4, 5, h: 19, min: 30)
         let apr5e = d(2026, 4, 5, h: 22, min: 0)
-        let apr5t = t(apr5s, apr5e)
         add(2026, 4, 5, CalendarEvent(
             id: "demo-apr-002",
             eventIdentifier: nil,
             day: 5,
-            start: apr5t.0,
-            end: apr5t.1,
             startDate: apr5s,
             endDate: apr5e,
             title: "Chamber orchestra concert",
@@ -280,13 +251,10 @@ enum DemoFixtures {
         // 2026-04-18 (SampleData “today”)
         let apr18a = d(2026, 4, 18, h: 8, min: 0)
         let apr18b = d(2026, 4, 18, h: 9, min: 30)
-        let apr18at = t(apr18a, apr18b)
         add(2026, 4, 18, CalendarEvent(
             id: "demo-apr-today-001",
             eventIdentifier: nil,
             day: 18,
-            start: apr18at.0,
-            end: apr18at.1,
             startDate: apr18a,
             endDate: apr18b,
             title: "Breakfast with Maria",
@@ -305,13 +273,10 @@ enum DemoFixtures {
         )
         let apr18c = d(2026, 4, 18, h: 12, min: 30)
         let apr18d = d(2026, 4, 18, h: 13, min: 45)
-        let apr18ct = t(apr18c, apr18d)
         add(2026, 4, 18, CalendarEvent(
             id: "demo-apr-today-002",
             eventIdentifier: nil,
             day: 18,
-            start: apr18ct.0,
-            end: apr18ct.1,
             startDate: apr18c,
             endDate: apr18d,
             title: "Team lunch",
@@ -330,13 +295,10 @@ enum DemoFixtures {
         ))
         let apr18e = d(2026, 4, 18, h: 20, min: 15)
         let apr18f = d(2026, 4, 18, h: 23, min: 15)
-        let apr18et = t(apr18e, apr18f)
         add(2026, 4, 18, CalendarEvent(
             id: "demo-apr-today-004",
             eventIdentifier: nil,
             day: 18,
-            start: apr18et.0,
-            end: apr18et.1,
             startDate: apr18e,
             endDate: apr18f,
             title: "Movie: Dune Part Two",
@@ -384,13 +346,10 @@ enum DemoFixtures {
         addTimed("demo-may-107", 2026, 5, 8, 14, 0, 15, 30, title: "1:1 — career chat", tint: butter, location: "Coffee Lab")
         let may9s = d(2026, 5, 9, h: 10, min: 0)
         let may9e = d(2026, 5, 9, h: 14, min: 0)
-        let may9t = t(may9s, may9e)
         add(2026, 5, 9, CalendarEvent(
             id: "demo-may-002",
             eventIdentifier: nil,
             day: 9,
-            start: may9t.0,
-            end: may9t.1,
             startDate: may9s,
             endDate: may9e,
             title: "Mother’s Day brunch",
@@ -467,13 +426,10 @@ enum DemoFixtures {
         addTimed("demo-jun-120", 2026, 6, 20, 8, 45, 10, 15, title: "Yard work party", tint: peach, location: "Front + side yard")
         let jun21s = d(2026, 6, 21, h: 18, min: 0)
         let jun21e = d(2026, 6, 21, h: 22, min: 30)
-        let jun21t = t(jun21s, jun21e)
         add(2026, 6, 21, CalendarEvent(
             id: "demo-jun-001",
             eventIdentifier: nil,
             day: 21,
-            start: jun21t.0,
-            end: jun21t.1,
             startDate: jun21s,
             endDate: jun21e,
             title: "Summer solstice grill-out",

--- a/Hibi/Models/EventStore.swift
+++ b/Hibi/Models/EventStore.swift
@@ -32,14 +32,6 @@ final class EventStore {
         return c
     }()
 
-    private let timeFormatter: DateFormatter = {
-        let f = DateFormatter()
-        f.locale = .autoupdatingCurrent
-        f.dateStyle = .none
-        f.timeStyle = .short
-        return f
-    }()
-
     init() {
         let permission = Permission.calendar(access: .full)
         self.hasCalendarAccess = permission.authorized
@@ -226,7 +218,7 @@ final class EventStore {
         for d in grouped.keys {
             grouped[d]?.sort { lhs, rhs in
                 if lhs.allDay != rhs.allDay { return lhs.allDay && !rhs.allDay }
-                return (lhs.start ?? "") < (rhs.start ?? "")
+                return (lhs.startDate ?? .distantPast) < (rhs.startDate ?? .distantPast)
             }
         }
 
@@ -366,15 +358,11 @@ final class EventStore {
     // MARK: - Adapters
 
     private func makeCalendarEvent(from ek: EKEvent, day: Int) -> CalendarEvent {
-        let start: String? = ek.isAllDay ? nil : timeFormatter.string(from: ek.startDate)
-        let end: String? = ek.isAllDay ? nil : timeFormatter.string(from: ek.endDate)
         let tint = Color.pastelized(cgColor: ek.calendar?.cgColor)
         return CalendarEvent(
             id: ek.eventIdentifier ?? UUID().uuidString,
             eventIdentifier: ek.eventIdentifier,
             day: day,
-            start: start,
-            end: end,
             startDate: ek.startDate,
             endDate: ek.endDate,
             title: ek.title ?? "",

--- a/Hibi/Models/Preferences.swift
+++ b/Hibi/Models/Preferences.swift
@@ -1,0 +1,96 @@
+import Foundation
+
+/// Settings-screen preference for temperature display unit.
+///
+/// Default is `.system`, which resolves to Fahrenheit in US-units regions
+/// (`Locale.measurementSystem == .us`) and Celsius everywhere else —
+/// matching the rest of the system's behavior.
+enum TemperatureUnit: String, CaseIterable, Identifiable {
+    case system, celsius, fahrenheit
+
+    static let defaultsKey = "temperatureUnit"
+
+    var id: String { rawValue }
+
+    var labelResource: LocalizedStringResource {
+        switch self {
+        case .system:     "System"
+        case .celsius:    "Celsius"
+        case .fahrenheit: "Fahrenheit"
+        }
+    }
+
+    /// The concrete unit to render in, resolving `.system` through the current locale.
+    var resolved: UnitTemperature {
+        switch self {
+        case .system:
+            return Locale.autoupdatingCurrent.measurementSystem == .us ? .fahrenheit : .celsius
+        case .celsius:    return .celsius
+        case .fahrenheit: return .fahrenheit
+        }
+    }
+
+    /// Converts a Celsius reading to this unit and rounds to the nearest integer.
+    /// `DayWeather` stores Celsius with full precision so rounding only happens at display.
+    func display(celsius: Double) -> Int {
+        let m = Measurement<UnitTemperature>(value: celsius, unit: .celsius)
+        return Int(m.converted(to: resolved).value.rounded())
+    }
+}
+
+/// Settings-screen preference for clock format.
+///
+/// Default is `.system`, which follows the user's iOS region settings
+/// (short-time style on `Locale.autoupdatingCurrent`).
+enum TimeFormat: String, CaseIterable, Identifiable {
+    case system, twelveHour, twentyFourHour
+
+    static let defaultsKey = "timeFormat"
+
+    var id: String { rawValue }
+
+    var labelResource: LocalizedStringResource {
+        switch self {
+        case .system:          "System"
+        case .twelveHour:      "12-hour"
+        case .twentyFourHour:  "24-hour"
+        }
+    }
+
+    /// Shared formatters — `DateFormatter` is documented thread-safe on iOS 7+
+    /// for 64-bit apps, so the same instance can service every view.
+    private static let systemFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.locale = .autoupdatingCurrent
+        f.dateStyle = .none
+        f.timeStyle = .short
+        return f
+    }()
+
+    private static let twelveHourFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.dateFormat = "h:mm a"
+        return f
+    }()
+
+    private static let twentyFourHourFormatter: DateFormatter = {
+        let f = DateFormatter()
+        // en_GB ensures 24-hour even if the device's region prefers AM/PM.
+        f.locale = Locale(identifier: "en_GB")
+        f.dateFormat = "HH:mm"
+        return f
+    }()
+
+    var formatter: DateFormatter {
+        switch self {
+        case .system:         Self.systemFormatter
+        case .twelveHour:     Self.twelveHourFormatter
+        case .twentyFourHour: Self.twentyFourHourFormatter
+        }
+    }
+
+    func string(from date: Date) -> String {
+        formatter.string(from: date)
+    }
+}

--- a/Hibi/Models/WeatherStore.swift
+++ b/Hibi/Models/WeatherStore.swift
@@ -128,8 +128,8 @@ final class WeatherStore: NSObject {
         for day in weather.dailyForecast {
             let comps = calendar.dateComponents([.year, .month, .day], from: day.date)
             guard let y = comps.year, let m = comps.month, let d = comps.day else { continue }
-            let high = Int(day.highTemperature.converted(to: .celsius).value.rounded())
-            let low = Int(day.lowTemperature.converted(to: .celsius).value.rounded())
+            let high = day.highTemperature.converted(to: .celsius).value
+            let low = day.lowTemperature.converted(to: .celsius).value
             byDay[DayKey(year: y, month: m, day: d)] = DayWeather(
                 high: high,
                 low: low,

--- a/Hibi/Views/Components/DayEventRow.swift
+++ b/Hibi/Views/Components/DayEventRow.swift
@@ -6,15 +6,25 @@ struct DayEventRow: View {
     /// Ignored for all-day events — those always render fully filled.
     var progress: Double = 0
 
+    @AppStorage(TimeFormat.defaultsKey) private var timeFormatRaw: String = TimeFormat.system.rawValue
+
+    private var timeFormat: TimeFormat {
+        TimeFormat(rawValue: timeFormatRaw) ?? .system
+    }
+
     private var fillAmount: Double {
         event.allDay ? 1 : max(0, min(1, progress))
+    }
+
+    private var startText: String {
+        event.startDate.map { timeFormat.string(from: $0) } ?? ""
     }
 
     var body: some View {
         HStack(spacing: 0) {
             // "ALL DAY" goes through LocalizedStringKey (auto-localized);
-            // formatted times are already locale-formatted by EventStore.
-            timeLabel(event.allDay ? Text("ALL DAY") : Text(verbatim: event.start ?? ""))
+            // timed events format against the user's time-format preference.
+            timeLabel(event.allDay ? Text("ALL DAY") : Text(verbatim: startText))
             Rectangle()
                 .fill(event.tint.opacity(0.4))
                 .frame(width: 1)

--- a/Hibi/Views/Components/EventCard.swift
+++ b/Hibi/Views/Components/EventCard.swift
@@ -5,8 +5,20 @@ struct EventCard: View {
     /// 0 before the event starts, 1 after it ends. Ignored for all-day events.
     var progress: Double = 0
 
+    @AppStorage(TimeFormat.defaultsKey) private var timeFormatRaw: String = TimeFormat.system.rawValue
+
+    private var timeFormat: TimeFormat {
+        TimeFormat(rawValue: timeFormatRaw) ?? .system
+    }
+
     private var fillAmount: Double {
         event.allDay ? 1 : max(0, min(1, progress))
+    }
+
+    private var timeRange: String {
+        let start = event.startDate.map { timeFormat.string(from: $0) } ?? ""
+        let end = event.endDate.map { timeFormat.string(from: $0) } ?? ""
+        return "\(start)–\(end)"
     }
 
     var body: some View {
@@ -58,7 +70,7 @@ struct EventCard: View {
                     .foregroundStyle(.primary)
                     .lineLimit(1)
                 HStack(spacing: 8) {
-                    Text(verbatim: "\(event.start ?? "")–\(event.end ?? "")")
+                    Text(verbatim: timeRange)
                         .font(.system(size: 10.5, design: .monospaced))
                         .tracking(0.2)
                         .foregroundStyle(.secondary)

--- a/Hibi/Views/DayView.swift
+++ b/Hibi/Views/DayView.swift
@@ -472,14 +472,16 @@ private struct PageContent: View {
     let preview: Bool
 
     @AppStorage("useSimpleFont") private var useSimpleFont: Bool = false
+    @AppStorage(TimeFormat.defaultsKey) private var timeFormatRaw: String = TimeFormat.system.rawValue
+    @AppStorage(TemperatureUnit.defaultsKey) private var temperatureUnitRaw: String = TemperatureUnit.system.rawValue
 
-    private static let sunFormatter: DateFormatter = {
-        let f = DateFormatter()
-        f.locale = .autoupdatingCurrent
-        f.dateStyle = .none
-        f.timeStyle = .short
-        return f
-    }()
+    private var timeFormat: TimeFormat {
+        TimeFormat(rawValue: timeFormatRaw) ?? .system
+    }
+
+    private var temperatureUnit: TemperatureUnit {
+        TemperatureUnit(rawValue: temperatureUnitRaw) ?? .system
+    }
 
     var body: some View {
         VStack(spacing: 0) {
@@ -500,7 +502,7 @@ private struct PageContent: View {
                 Image(systemName: "sunrise")
                     .font(.system(size: 16))
                     .foregroundStyle(.secondary)
-                Text(weather?.sunrise.map { Self.sunFormatter.string(from: $0) } ?? "")
+                Text(weather?.sunrise.map { timeFormat.string(from: $0) } ?? "")
                     .font(.system(size: 9.5, design: .monospaced))
                     .tracking(0.6)
                     .foregroundStyle(.secondary)
@@ -516,7 +518,7 @@ private struct PageContent: View {
                 Image(systemName: "sunset")
                     .font(.system(size: 16))
                     .foregroundStyle(.secondary)
-                Text(weather?.sunset.map { Self.sunFormatter.string(from: $0) } ?? "")
+                Text(weather?.sunset.map { timeFormat.string(from: $0) } ?? "")
                     .font(.system(size: 9.5, design: .monospaced))
                     .tracking(0.6)
                     .foregroundStyle(.secondary)
@@ -567,10 +569,10 @@ private struct PageContent: View {
                     .foregroundStyle(.secondary)
                 VStack(alignment: .leading, spacing: 0) {
                     HStack(spacing: 0) {
-                        Text(verbatim: "\(weather?.high ?? 0)°")
+                        Text(verbatim: "\(temperatureUnit.display(celsius: weather?.high ?? 0))°")
                             .font(.system(size: 15, weight: .medium))
                             .tracking(-0.3)
-                        Text(verbatim: " / \(weather?.low ?? 0)°")
+                        Text(verbatim: " / \(temperatureUnit.display(celsius: weather?.low ?? 0))°")
                             .font(.system(size: 15))
                             .foregroundStyle(.secondary)
                     }

--- a/Hibi/Views/SettingsView.swift
+++ b/Hibi/Views/SettingsView.swift
@@ -13,6 +13,8 @@ struct SettingsView: View {
     @AppStorage("appearance") private var appearanceRaw: String = Appearance.system.rawValue
     @AppStorage("invertDaySwipe") private var invertDaySwipe: Bool = false
     @AppStorage("useSimpleFont") private var useSimpleFont: Bool = false
+    @AppStorage(TemperatureUnit.defaultsKey) private var temperatureUnitRaw: String = TemperatureUnit.system.rawValue
+    @AppStorage(TimeFormat.defaultsKey) private var timeFormatRaw: String = TimeFormat.system.rawValue
     @State private var showWhatsNew = false
 
     enum Appearance: String, CaseIterable, Identifiable {
@@ -46,6 +48,19 @@ struct SettingsView: View {
                 Section("Day View") {
                     Toggle("Invert swipe direction", isOn: $invertDaySwipe)
                         .tint(.black)
+                }
+
+                Section("Units") {
+                    Picker("Temperature", selection: $temperatureUnitRaw) {
+                        ForEach(TemperatureUnit.allCases) { u in
+                            Text(u.labelResource).tag(u.rawValue)
+                        }
+                    }
+                    Picker("Time", selection: $timeFormatRaw) {
+                        ForEach(TimeFormat.allCases) { f in
+                            Text(f.labelResource).tag(f.rawValue)
+                        }
+                    }
                 }
 
                 Section("Calendars") {

--- a/Hibi/Views/StreamView.swift
+++ b/Hibi/Views/StreamView.swift
@@ -230,6 +230,11 @@ private struct StreamDayRow: View {
     @Environment(WeatherStore.self) private var weatherStore
     @State private var isDropTargeted: Bool = false
     @AppStorage("useSimpleFont") private var useSimpleFont: Bool = false
+    @AppStorage(TemperatureUnit.defaultsKey) private var temperatureUnitRaw: String = TemperatureUnit.system.rawValue
+
+    private var temperatureUnit: TemperatureUnit {
+        TemperatureUnit(rawValue: temperatureUnitRaw) ?? .system
+    }
 
     var body: some View {
         let events = eventStore.events(year: year, month: month, day: day)
@@ -391,10 +396,10 @@ private struct StreamDayRow: View {
             VStack(spacing: 2) {
                 WeatherIcon(code: wx.code, size: 18)
                     .foregroundStyle(.secondary)
-                Text(verbatim: "\(wx.high)°")
+                Text(verbatim: "\(temperatureUnit.display(celsius: wx.high))°")
                     .font(.system(size: 10, weight: .medium))
                     .foregroundStyle(.secondary)
-                Text(verbatim: "\(wx.low)°")
+                Text(verbatim: "\(temperatureUnit.display(celsius: wx.low))°")
                     .font(.system(size: 9))
                     .foregroundStyle(.tertiary)
             }


### PR DESCRIPTION
Closes #21. Adds two Settings pickers so users can override the
locale-derived defaults:

- Temperature: System / Celsius / Fahrenheit
- Time: System / 12-hour / 24-hour

"System" preserves today's behavior (locale measurement system for
temp, locale-short style for time), so existing users see no change.

Formatting now happens at display time against the preference:
CalendarEvent no longer carries pre-baked start/end strings, and
DayWeather stores Celsius as Double so unit conversion rounds once
at render. Event sort in EventStore + DemoFixtures moves to startDate
(the old HH:mm string sort would break under 12-hour format).