### PR TITLE
Show ISO calendar week on the Day view Kalenderblatt

### DIFF
--- a/Hibi/Models/SampleData.swift
+++ b/Hibi/Models/SampleData.swift
@@ -57,6 +57,19 @@ enum SampleData {
         return cal.component(.weekday, from: date) - 1
     }
 
+    /// ISO 8601 week number (Monday-start, week 1 contains the first Thursday).
+    /// Uses the dedicated `.iso8601` calendar so the result is independent of
+    /// the user's locale or `firstWeekday` setting.
+    static func isoWeek(year: Int, month: Int, day: Int) -> Int {
+        var comps = DateComponents()
+        comps.year = year
+        comps.month = month
+        comps.day = day
+        let cal = Calendar(identifier: .iso8601)
+        guard let date = cal.date(from: comps) else { return 0 }
+        return cal.component(.weekOfYear, from: date)
+    }
+
     static func isToday(year: Int, month: Int, day: Int) -> Bool {
         let t = todayComponents
         return year == t.year && month == t.month && day == t.day

--- a/Hibi/Views/DayView.swift
+++ b/Hibi/Views/DayView.swift
@@ -643,10 +643,10 @@ private struct PageContent: View {
                     }
                 }
             // Month name is already localized via the MonthNames accessor;
-            // separator + year are locale-invariant. `verbatim:` skips the
-            // LocalizedStringKey lookup so we don't pollute the catalog with a
-            // generic "%@ · %@" key.
-            Text(verbatim: "\(MonthNames.full[month - 1]) · \(String(year))")
+            // separator + year + ISO week marker are locale-invariant.
+            // `verbatim:` skips the LocalizedStringKey lookup so we don't
+            // pollute the catalog with a generic "%@ · %@ · KW %d" key.
+            Text(verbatim: "\(MonthNames.full[month - 1]) · \(String(year)) · KW \(SampleData.isoWeek(year: year, month: month, day: day))")
                 .font(.appSerif(size: 13, italic: true, simple: useSimpleFont))
                 .foregroundStyle(.secondary)
                 .padding(.top, 2)

--- a/Hibi/Views/MonthView.swift
+++ b/Hibi/Views/MonthView.swift
@@ -14,10 +14,9 @@ struct MonthView: View {
         let cells: [Int?] = Array(repeating: nil, count: firstWeekday)
             + (1...totalDays).map { Optional($0) }
         let padded = cells + Array(repeating: nil, count: (7 - cells.count % 7) % 7)
-        let weekCount = padded.count / 7
 
         VStack(alignment: .leading, spacing: 0) {
-            header(weekCount: weekCount)
+            header(totalDays: totalDays)
             weekdayHeader
             grid(cells: padded)
         }
@@ -27,8 +26,14 @@ struct MonthView: View {
         }
     }
 
-    private func header(weekCount: Int) -> some View {
-        VStack(alignment: .leading, spacing: -4) {
+    private func header(totalDays: Int) -> some View {
+        // ISO calendar-week range spanned by this month. Wraps year boundaries
+        // naturally (e.g. December may end in KW 1 of the next ISO week-year).
+        let firstKW = SampleData.isoWeek(year: year, month: month, day: 1)
+        let lastKW = SampleData.isoWeek(year: year, month: month, day: totalDays)
+        let kwLabel = firstKW == lastKW ? "KW \(firstKW)" : "KW \(firstKW)–\(lastKW)"
+
+        return VStack(alignment: .leading, spacing: -4) {
             Text(String(year))
                 .font(.appSerif(size: 15, italic: true, simple: useSimpleFont))
                 .tracking(0.4)
@@ -39,7 +44,7 @@ struct MonthView: View {
                     .tracking(-1.5)
                     .foregroundStyle(.primary)
                 Spacer()
-                Text("Wk \(weekCount)")
+                Text(verbatim: kwLabel)
                     .font(.system(size: 11))
                     .tracking(1.5)
                     .foregroundStyle(.secondary)


### PR DESCRIPTION
Closes #42. Appends "KW N" to the month/year subtitle on the day card
so the current calendar week is visible at a glance, per Kai's feedback.
Uses the .iso8601 calendar so the week number is independent of the
user's locale or firstWeekday.