### PR TITLE
mark recurring events with a glyph in stream + day rows

### DIFF
--- a/Hibi/Models/CalendarEvent.swift
+++ b/Hibi/Models/CalendarEvent.swift
@@ -30,6 +30,7 @@ struct CalendarEvent: Identifiable, Hashable {
     let tint: Color
     let location: String?
     let allDay: Bool
+    let isRecurring: Bool
 
     init(id: String = UUID().uuidString,
          eventIdentifier: String? = nil,
@@ -39,7 +40,8 @@ struct CalendarEvent: Identifiable, Hashable {
          title: String,
          tint: Color,
          location: String? = nil,
-         allDay: Bool = false) {
+         allDay: Bool = false,
+         isRecurring: Bool = false) {
         self.id = id
         self.eventIdentifier = eventIdentifier
         self.day = day
@@ -49,6 +51,7 @@ struct CalendarEvent: Identifiable, Hashable {
         self.tint = tint
         self.location = location
         self.allDay = allDay
+        self.isRecurring = isRecurring
     }
 }
 

--- a/Hibi/Models/DemoFixtures+English.swift
+++ b/Hibi/Models/DemoFixtures+English.swift
@@ -15,21 +15,23 @@ extension DemoFixtures {
             _ id: String,
             _ y: Int, _ m: Int, _ day: Int,
             _ h1: Int, _ m1: Int, _ h2: Int, _ m2: Int,
-            title: String, tint: Color, location: String? = nil
+            title: String, tint: Color, location: String? = nil,
+            recurring: Bool = false
         ) {
             let s = date(y, m, day, h: h1, min: m1)
             let e = date(y, m, day, h: h2, min: m2)
             add(y, m, day, CalendarEvent(
                 id: id, eventIdentifier: nil, day: day,
                 startDate: s, endDate: e,
-                title: title, tint: tint, location: location, allDay: false
+                title: title, tint: tint, location: location, allDay: false,
+                isRecurring: recurring
             ))
         }
 
         // MARK: February
         add(2026, 2, 1, CalendarEvent(id: "demo-feb-101", eventIdentifier: nil, day: 1, title: "Monthly budget review", tint: butter, allDay: true))
         timed("demo-feb-101b", 2026, 2, 1, 15, 0, 15, 45, title: "Quarterly planning — finance", tint: sea, location: "Zoom")
-        timed("demo-feb-102", 2026, 2, 2, 9, 0, 9, 45, title: "Yoga — early bird", tint: mint, location: "Studio North")
+        timed("demo-feb-102", 2026, 2, 2, 9, 0, 9, 45, title: "Yoga — early bird", tint: mint, location: "Studio North", recurring: true)
         add(2026, 2, 3, CalendarEvent(id: "demo-feb-001", eventIdentifier: nil, day: 3, title: "Anna's birthday", tint: rose, allDay: true))
         timed("demo-feb-001b", 2026, 2, 3, 19, 0, 22, 0, title: "Birthday dinner — close friends", tint: lilac, location: "Saffron Table")
         timed("demo-feb-103", 2026, 2, 4, 12, 0, 12, 30, title: "Dentist — quick polish", tint: sea, location: "Bright Smile Clinic")
@@ -37,11 +39,11 @@ extension DemoFixtures {
         timed("demo-feb-106", 2026, 2, 7, 10, 30, 11, 30, title: "Book club", tint: sky, location: "River Café")
         timed("demo-feb-106b", 2026, 2, 7, 16, 0, 17, 0, title: "Groceries + meal prep", tint: butter, location: "Whole Foods")
         timed("demo-feb-107", 2026, 2, 8, 15, 0, 16, 0, title: "Kids' soccer practice", tint: coral, location: "East Fields")
-        timed("demo-feb-108", 2026, 2, 9, 8, 30, 9, 15, title: "1:1 with Alex", tint: sea, location: "Meet — Boreal room")
+        timed("demo-feb-108", 2026, 2, 9, 8, 30, 9, 15, title: "1:1 with Alex", tint: sea, location: "Meet — Boreal room", recurring: true)
         timed("demo-feb-109", 2026, 2, 10, 19, 0, 20, 30, title: "Jazz night", tint: lilac, location: "Blue Note Loft")
         add(2026, 2, 11, CalendarEvent(id: "demo-feb-110", eventIdentifier: nil, day: 11, title: "Car service & inspection", tint: butter, location: "AutoCare Plus", allDay: true))
         timed("demo-feb-110b", 2026, 2, 11, 14, 0, 15, 30, title: "Pick up rental car", tint: coral, location: "AutoCare Plus")
-        timed("demo-feb-112", 2026, 2, 13, 17, 30, 18, 30, title: "Therapy session", tint: sky)
+        timed("demo-feb-112", 2026, 2, 13, 17, 30, 18, 30, title: "Therapy session", tint: sky, recurring: true)
         add(2026, 2, 14, CalendarEvent(
             id: "demo-feb-002", eventIdentifier: nil, day: 14,
             startDate: date(2026, 2, 14, h: 10, min: 0),
@@ -154,12 +156,13 @@ extension DemoFixtures {
             endDate: date(2026, 4, 18, h: 9, min: 30),
             title: "Breakfast with Maria", tint: peach, location: "Schmitt Bakery", allDay: false
         ))
-        timed("demo-apr-today-progress", 2026, 4, 18, 10, 0, 20, 0, title: "App Store polish — focus block", tint: sea, location: "Home office")
+        timed("demo-apr-today-progress", 2026, 4, 18, 10, 0, 20, 0, title: "App Store polish — focus block", tint: sea, location: "Home office", recurring: true)
         add(2026, 4, 18, CalendarEvent(
             id: "demo-apr-today-002", eventIdentifier: nil, day: 18,
             startDate: date(2026, 4, 18, h: 12, min: 30),
             endDate: date(2026, 4, 18, h: 13, min: 45),
-            title: "Team lunch", tint: mint, location: "Osteria Due", allDay: false
+            title: "Team lunch", tint: mint, location: "Osteria Due", allDay: false,
+            isRecurring: true
         ))
         add(2026, 4, 18, CalendarEvent(id: "demo-apr-today-003", eventIdentifier: nil, day: 18, title: "Family gathering (all day)", tint: rose, location: "Grandparents' garden", allDay: true))
         add(2026, 4, 18, CalendarEvent(

--- a/Hibi/Models/DemoFixtures+German.swift
+++ b/Hibi/Models/DemoFixtures+German.swift
@@ -15,21 +15,23 @@ extension DemoFixtures {
             _ id: String,
             _ y: Int, _ m: Int, _ day: Int,
             _ h1: Int, _ m1: Int, _ h2: Int, _ m2: Int,
-            title: String, tint: Color, location: String? = nil
+            title: String, tint: Color, location: String? = nil,
+            recurring: Bool = false
         ) {
             let s = date(y, m, day, h: h1, min: m1)
             let e = date(y, m, day, h: h2, min: m2)
             add(y, m, day, CalendarEvent(
                 id: id, eventIdentifier: nil, day: day,
                 startDate: s, endDate: e,
-                title: title, tint: tint, location: location, allDay: false
+                title: title, tint: tint, location: location, allDay: false,
+                isRecurring: recurring
             ))
         }
 
         // MARK: Februar
         add(2026, 2, 1, CalendarEvent(id: "demo-feb-101", eventIdentifier: nil, day: 1, title: "Monatsbudget prüfen", tint: butter, allDay: true))
         timed("demo-feb-101b", 2026, 2, 1, 15, 0, 15, 45, title: "Quartalsplanung — Finanzen", tint: sea, location: "Zoom")
-        timed("demo-feb-102", 2026, 2, 2, 9, 0, 9, 45, title: "Yoga — Frühkurs", tint: mint, location: "Studio Nord")
+        timed("demo-feb-102", 2026, 2, 2, 9, 0, 9, 45, title: "Yoga — Frühkurs", tint: mint, location: "Studio Nord", recurring: true)
         add(2026, 2, 3, CalendarEvent(id: "demo-feb-001", eventIdentifier: nil, day: 3, title: "Annas Geburtstag", tint: rose, allDay: true))
         timed("demo-feb-001b", 2026, 2, 3, 19, 0, 22, 0, title: "Geburtstagsessen — enge Freunde", tint: lilac, location: "Gasthof zur Linde")
         timed("demo-feb-103", 2026, 2, 4, 12, 0, 12, 30, title: "Zahnarzt — Politur", tint: sea, location: "Praxis Dr. Meier")
@@ -38,12 +40,12 @@ extension DemoFixtures {
         timed("demo-feb-106", 2026, 2, 7, 10, 30, 11, 30, title: "Lesekreis", tint: sky, location: "Café am Fluss")
         timed("demo-feb-106b", 2026, 2, 7, 16, 0, 17, 0, title: "Einkaufen + Meal Prep", tint: butter, location: "REWE")
         timed("demo-feb-107", 2026, 2, 8, 15, 0, 16, 0, title: "Fußball-Training der Kinder", tint: coral, location: "Sportplatz Ost")
-        timed("demo-feb-108", 2026, 2, 9, 8, 30, 9, 15, title: "1:1 mit Alex", tint: sea, location: "Meet — Raum Alpen")
+        timed("demo-feb-108", 2026, 2, 9, 8, 30, 9, 15, title: "1:1 mit Alex", tint: sea, location: "Meet — Raum Alpen", recurring: true)
         timed("demo-feb-109", 2026, 2, 10, 19, 0, 20, 30, title: "Jazz-Abend", tint: lilac, location: "Blue Note Keller")
         add(2026, 2, 11, CalendarEvent(id: "demo-feb-110", eventIdentifier: nil, day: 11, title: "Auto TÜV + Inspektion", tint: butter, location: "ATU Werkstatt", allDay: true))
         timed("demo-feb-110b", 2026, 2, 11, 14, 0, 15, 30, title: "Mietwagen abholen", tint: coral, location: "ATU Werkstatt")
         // Feb 12: sparse
-        timed("demo-feb-112", 2026, 2, 13, 17, 30, 18, 30, title: "Therapie-Sitzung", tint: sky)
+        timed("demo-feb-112", 2026, 2, 13, 17, 30, 18, 30, title: "Therapie-Sitzung", tint: sky, recurring: true)
         add(2026, 2, 14, CalendarEvent(
             id: "demo-feb-002", eventIdentifier: nil, day: 14,
             startDate: date(2026, 2, 14, h: 10, min: 0),
@@ -165,12 +167,13 @@ extension DemoFixtures {
             endDate: date(2026, 4, 18, h: 9, min: 30),
             title: "Frühstück mit Maria", tint: peach, location: "Bäckerei Schmitt", allDay: false
         ))
-        timed("demo-apr-today-progress", 2026, 4, 18, 10, 0, 20, 0, title: "App-Store-Feinschliff — Fokusblock", tint: sea, location: "Home Office")
+        timed("demo-apr-today-progress", 2026, 4, 18, 10, 0, 20, 0, title: "App-Store-Feinschliff — Fokusblock", tint: sea, location: "Home Office", recurring: true)
         add(2026, 4, 18, CalendarEvent(
             id: "demo-apr-today-002", eventIdentifier: nil, day: 18,
             startDate: date(2026, 4, 18, h: 12, min: 30),
             endDate: date(2026, 4, 18, h: 13, min: 45),
-            title: "Team-Mittagessen", tint: mint, location: "Osteria Due", allDay: false
+            title: "Team-Mittagessen", tint: mint, location: "Osteria Due", allDay: false,
+            isRecurring: true
         ))
         add(2026, 4, 18, CalendarEvent(id: "demo-apr-today-003", eventIdentifier: nil, day: 18, title: "Familientreffen (ganztägig)", tint: rose, location: "Garten der Großeltern", allDay: true))
         add(2026, 4, 18, CalendarEvent(

--- a/Hibi/Models/DemoFixtures+Japanese.swift
+++ b/Hibi/Models/DemoFixtures+Japanese.swift
@@ -15,21 +15,23 @@ extension DemoFixtures {
             _ id: String,
             _ y: Int, _ m: Int, _ day: Int,
             _ h1: Int, _ m1: Int, _ h2: Int, _ m2: Int,
-            title: String, tint: Color, location: String? = nil
+            title: String, tint: Color, location: String? = nil,
+            recurring: Bool = false
         ) {
             let s = date(y, m, day, h: h1, min: m1)
             let e = date(y, m, day, h: h2, min: m2)
             add(y, m, day, CalendarEvent(
                 id: id, eventIdentifier: nil, day: day,
                 startDate: s, endDate: e,
-                title: title, tint: tint, location: location, allDay: false
+                title: title, tint: tint, location: location, allDay: false,
+                isRecurring: recurring
             ))
         }
 
         // MARK: 2月
         add(2026, 2, 1, CalendarEvent(id: "demo-feb-101", eventIdentifier: nil, day: 1, title: "月次予算レビュー", tint: butter, allDay: true))
         timed("demo-feb-101b", 2026, 2, 1, 15, 0, 15, 45, title: "四半期計画 — 経理", tint: sea, location: "Zoom")
-        timed("demo-feb-102", 2026, 2, 2, 9, 0, 9, 45, title: "朝ヨガ", tint: mint, location: "スタジオ青山")
+        timed("demo-feb-102", 2026, 2, 2, 9, 0, 9, 45, title: "朝ヨガ", tint: mint, location: "スタジオ青山", recurring: true)
         add(2026, 2, 3, CalendarEvent(id: "demo-feb-001", eventIdentifier: nil, day: 3, title: "節分 — 豆まき", tint: rose, allDay: true))
         timed("demo-feb-001b", 2026, 2, 3, 19, 0, 22, 0, title: "恵方巻きディナー", tint: lilac, location: "自宅")
         timed("demo-feb-103", 2026, 2, 4, 12, 0, 12, 30, title: "歯医者 — クリーニング", tint: sea, location: "田中歯科")
@@ -38,12 +40,12 @@ extension DemoFixtures {
         timed("demo-feb-106", 2026, 2, 7, 10, 30, 11, 30, title: "読書会", tint: sky, location: "蔦屋書店 代官山")
         timed("demo-feb-106b", 2026, 2, 7, 16, 0, 17, 0, title: "買い出し + 作り置き", tint: butter, location: "成城石井")
         timed("demo-feb-107", 2026, 2, 8, 15, 0, 16, 0, title: "子どものサッカー練習", tint: coral, location: "駒沢グラウンド")
-        timed("demo-feb-108", 2026, 2, 9, 8, 30, 9, 15, title: "1on1 ミーティング", tint: sea, location: "Meet — 会議室A")
+        timed("demo-feb-108", 2026, 2, 9, 8, 30, 9, 15, title: "1on1 ミーティング", tint: sea, location: "Meet — 会議室A", recurring: true)
         timed("demo-feb-109", 2026, 2, 10, 19, 0, 20, 30, title: "ジャズライブ", tint: lilac, location: "Blue Note 東京")
         add(2026, 2, 11, CalendarEvent(id: "demo-feb-110", eventIdentifier: nil, day: 11, title: "建国記念の日", tint: butter, allDay: true))
         timed("demo-feb-110b", 2026, 2, 11, 14, 0, 15, 30, title: "車の点検受け取り", tint: coral, location: "オートバックス")
         // 2/12: sparse
-        timed("demo-feb-112", 2026, 2, 13, 17, 30, 18, 30, title: "カウンセリング", tint: sky)
+        timed("demo-feb-112", 2026, 2, 13, 17, 30, 18, 30, title: "カウンセリング", tint: sky, recurring: true)
         add(2026, 2, 14, CalendarEvent(
             id: "demo-feb-002", eventIdentifier: nil, day: 14,
             startDate: date(2026, 2, 14, h: 10, min: 0),
@@ -166,12 +168,13 @@ extension DemoFixtures {
             endDate: date(2026, 4, 18, h: 9, min: 30),
             title: "朝食 — 美咲と", tint: peach, location: "パン屋 小麦の丘", allDay: false
         ))
-        timed("demo-apr-today-progress", 2026, 4, 18, 10, 0, 20, 0, title: "App Store仕上げ — 集中ブロック", tint: sea, location: "ホームオフィス")
+        timed("demo-apr-today-progress", 2026, 4, 18, 10, 0, 20, 0, title: "App Store仕上げ — 集中ブロック", tint: sea, location: "ホームオフィス", recurring: true)
         add(2026, 4, 18, CalendarEvent(
             id: "demo-apr-today-002", eventIdentifier: nil, day: 18,
             startDate: date(2026, 4, 18, h: 12, min: 30),
             endDate: date(2026, 4, 18, h: 13, min: 45),
-            title: "チームランチ", tint: mint, location: "トラットリア", allDay: false
+            title: "チームランチ", tint: mint, location: "トラットリア", allDay: false,
+            isRecurring: true
         ))
         add(2026, 4, 18, CalendarEvent(id: "demo-apr-today-003", eventIdentifier: nil, day: 18, title: "家族の集まり（終日）", tint: rose, location: "祖父母の家", allDay: true))
         add(2026, 4, 18, CalendarEvent(

--- a/Hibi/Models/EventStore.swift
+++ b/Hibi/Models/EventStore.swift
@@ -368,7 +368,8 @@ final class EventStore {
             title: ek.title ?? "",
             tint: tint,
             location: ek.location?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty,
-            allDay: ek.isAllDay
+            allDay: ek.isAllDay,
+            isRecurring: ek.hasRecurrenceRules
         )
     }
 }

--- a/Hibi/Views/Components/DayEventRow.swift
+++ b/Hibi/Views/Components/DayEventRow.swift
@@ -61,10 +61,15 @@ struct DayEventRow: View {
 
     private var titleBlock: some View {
         VStack(alignment: .leading, spacing: 1) {
-            Text(event.title)
-                .font(.system(size: 13.5, weight: .medium))
-                .tracking(-0.15)
-                .foregroundStyle(.primary)
+            HStack(spacing: 5) {
+                Text(event.title)
+                    .font(.system(size: 13.5, weight: .medium))
+                    .tracking(-0.15)
+                    .foregroundStyle(.primary)
+                if event.isRecurring {
+                    RecurringGlyph()
+                }
+            }
             if let loc = event.location {
                 Text(loc)
                     .font(.system(size: 11))

--- a/Hibi/Views/Components/EventCard.swift
+++ b/Hibi/Views/Components/EventCard.swift
@@ -35,9 +35,14 @@ struct EventCard: View {
                 .fill(event.tint)
                 .frame(width: 4, height: 14)
             VStack(alignment: .leading, spacing: 1) {
-                Text(event.title)
-                    .font(.system(size: 13, weight: .medium))
-                    .foregroundStyle(.primary)
+                HStack(spacing: 5) {
+                    Text(event.title)
+                        .font(.system(size: 13, weight: .medium))
+                        .foregroundStyle(.primary)
+                    if event.isRecurring {
+                        RecurringGlyph()
+                    }
+                }
                 Text("ALL DAY")
                     .font(.system(size: 10, weight: .semibold))
                     .tracking(1.1)
@@ -64,11 +69,16 @@ struct EventCard: View {
                 .frame(width: 4)
                 .padding(.vertical, 2)
             VStack(alignment: .leading, spacing: 2) {
-                Text(event.title)
-                    .font(.system(size: 13.5, weight: .medium))
-                    .tracking(-0.15)
-                    .foregroundStyle(.primary)
-                    .lineLimit(1)
+                HStack(spacing: 5) {
+                    Text(event.title)
+                        .font(.system(size: 13.5, weight: .medium))
+                        .tracking(-0.15)
+                        .foregroundStyle(.primary)
+                        .lineLimit(1)
+                    if event.isRecurring {
+                        RecurringGlyph()
+                    }
+                }
                 HStack(spacing: 8) {
                     Text(verbatim: timeRange)
                         .font(.system(size: 10.5, design: .monospaced))

--- a/Hibi/Views/Components/RecurringGlyph.swift
+++ b/Hibi/Views/Components/RecurringGlyph.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+
+/// Small "this event repeats" indicator shown next to a title in event rows/cards.
+struct RecurringGlyph: View {
+    var size: CGFloat = 9
+
+    var body: some View {
+        Image(systemName: "arrow.triangle.2.circlepath")
+            .font(.system(size: size, weight: .semibold))
+            .foregroundStyle(.secondary)
+            .accessibilityLabel(Text("Recurring"))
+    }
+}


### PR DESCRIPTION
Reads EKEvent.hasRecurrenceRules into a new CalendarEvent.isRecurring
flag, and shows a small arrow.triangle.2.circlepath next to the title
in EventCard and DayEventRow. Tags a handful of demo fixtures (yoga,
1:1, therapy, focus block, team lunch) as recurring across all locales
so screenshots show the indicator.

Closes #31