### PR TITLE
Add bottom padding to month grid (#36)

### DIFF
--- a/Hibi/Views/MonthView.swift
+++ b/Hibi/Views/MonthView.swift
@@ -20,6 +20,7 @@ struct MonthView: View {
             header(weekCount: weekCount)
             weekdayHeader
             grid(cells: padded)
+                .padding(.bottom, 12)
         }
         .padding(.horizontal, 20)
         .task(id: MonthKey(year: year, month: month)) {


### PR DESCRIPTION
Today-indicator circle (36×36) extends past the day-number frame (32×32),
so on the last row of a month it sat too close to the next month's
weekday divider. Adding 12pt below the grid gives the circle consistent
breathing room independent of the cell content.