### PR TITLE
fix: optically center today indicator on the digit

### DIFF
--- a/Hibi/Views/MonthView.swift
+++ b/Hibi/Views/MonthView.swift
@@ -113,6 +113,10 @@ private struct DayCell: View {
                             Circle()
                                 .strokeBorder(.primary, lineWidth: 1.25)
                                 .frame(width: 36, height: 36)
+                                // Optical centering: digit caps sit above the line-box
+                                // center (descender area below baseline is empty), and
+                                // serif side bearings on "0" extend slightly right.
+                                .offset(x: -0.5, y: -1.5)
                         }
                     }
 

--- a/Hibi/Views/StreamView.swift
+++ b/Hibi/Views/StreamView.swift
@@ -368,6 +368,10 @@ private struct StreamDayRow: View {
                         Circle()
                             .strokeBorder(.primary, lineWidth: 1.25)
                             .frame(width: 44, height: 44)
+                            // Optical centering: digit caps sit above the line-box
+                            // center (empty descender area below baseline) and the
+                            // serif "0" has more right-side bearing than "3"'s left.
+                            .offset(x: -0.5, y: -2)
                     }
                 }
                 .frame(minHeight: 36, alignment: .leading)


### PR DESCRIPTION
The digit's visible cap area sits above the line-box center because the
serif's descender area below the baseline is empty for numerals, so a
geometrically-centered halo looked low and slightly right of the digit
(most visible on "30" in the month view, per #35). Nudge the circle to
match the digit's optical center in both MonthView and StreamView.

Closes #35