### PR TITLE
Fix recurring event deletion to target correct occurrence

### DIFF
--- a/Hibi/Models/EventStore.swift
+++ b/Hibi/Models/EventStore.swift
@@ -409,6 +409,30 @@ final class EventStore {
     func ekEvent(matching event: CalendarEvent) -> EKEvent? {
         guard !isDemoMode else { return nil }
         guard let identifier = event.eventIdentifier else { return nil }
+
+        // For recurring events, `event(withIdentifier:)` returns the first
+        // occurrence (the series "master"). Handing that to
+        // EKEventEditViewController makes the "Delete This Event Only" action
+        // remove the past master rather than the occurrence the user tapped,
+        // so the visible occurrence persists. Re-query the day's occurrences
+        // and pick the one whose start matches the tapped instance.
+        if event.isRecurring, let occurrenceStart = event.startDate {
+            let dayStart = calendar.startOfDay(for: occurrenceStart)
+            if let dayEnd = calendar.date(byAdding: .day, value: 1, to: dayStart) {
+                let predicate = ekStore.predicateForEvents(
+                    withStart: dayStart, end: dayEnd, calendars: nil
+                )
+                let matches = ekStore.events(matching: predicate)
+                    .filter { $0.eventIdentifier == identifier }
+                if let exact = matches.min(by: {
+                    abs($0.startDate.timeIntervalSince(occurrenceStart))
+                        < abs($1.startDate.timeIntervalSince(occurrenceStart))
+                }) {
+                    return exact
+                }
+            }
+        }
+
         return ekStore.event(withIdentifier: identifier)
     }
 


### PR DESCRIPTION
## Summary
Fixed an issue where deleting a single occurrence of a recurring event would incorrectly remove the series master instead of the tapped instance.

## Key Changes
- Enhanced `ekEvent(matching:)` to properly handle recurring events by querying occurrences on the event's date rather than relying on the series master
- For recurring events, the method now:
  - Queries all events on the occurrence's day using `predicateForEvents(withStart:end:calendars:)`
  - Filters results to match the event identifier
  - Selects the occurrence whose start time is closest to the tapped event's start time
  - Falls back to the original behavior for non-recurring events

## Implementation Details
- The fix addresses a limitation in EventKit where `event(withIdentifier:)` returns the series master for recurring events
- When the master is passed to `EKEventEditViewController`, the "Delete This Event Only" action removes the master instead of the specific occurrence
- By matching on start time within the same day, the correct occurrence is reliably identified and returned

https://claude.ai/code/session_01SpRm4EuTpS4pRdViRYZKiz