### PR TITLE
Sync scroll position across tabs when switching

### DIFF
--- a/Hibi/ContentView.swift
+++ b/Hibi/ContentView.swift
@@ -8,6 +8,11 @@ enum CalendarTab: Hashable {
 struct ContentView: View {
     @State private var selection: CalendarTab = .day
     @State private var scrollToNowToken: Int = 0
+    /// Bumped whenever the user changes tabs. List-based tabs (Month, Week)
+    /// observe this and recenter their scroll position on the shared
+    /// displayed date so switching tabs lands near where the previous tab
+    /// was looking, instead of wherever each tab was last left.
+    @State private var tabSwitchToken: Int = 0
     @State private var showSettings = false
     @State private var displayedYear = SampleData.todayYear
     @State private var displayedMonth = SampleData.todayMonth
@@ -31,6 +36,8 @@ struct ContentView: View {
             set: { newValue in
                 if newValue == selection {
                     returnToNow()
+                } else {
+                    tabSwitchToken &+= 1
                 }
                 selection = newValue
             }
@@ -54,6 +61,7 @@ struct ContentView: View {
                         displayedYear: $displayedYear,
                         displayedMonth: $displayedMonth,
                         scrollToNowToken: scrollToNowToken,
+                        tabSwitchToken: tabSwitchToken,
                         onPickDay: { year, month, day in
                             displayedYear = year
                             displayedMonth = month
@@ -67,7 +75,9 @@ struct ContentView: View {
                     StreamView(
                         displayedYear: $displayedYear,
                         displayedMonth: $displayedMonth,
+                        selectedDay: $selectedDay,
                         scrollToNowToken: scrollToNowToken,
+                        tabSwitchToken: tabSwitchToken,
                         onPickDay: { year, month, day in
                             displayedYear = year
                             displayedMonth = month

--- a/Hibi/ContentView.swift
+++ b/Hibi/ContentView.swift
@@ -37,6 +37,14 @@ struct ContentView: View {
                 if newValue == selection {
                     returnToNow()
                 } else {
+                    // Leaving the Month tab: anchor the destination on day 1
+                    // of the displayed month, since Month has no concept of
+                    // a single "current day" — landing on whatever
+                    // selectedDay happened to hold (often mid-month) is
+                    // arbitrary.
+                    if selection == .month {
+                        selectedDay = 1
+                    }
                     tabSwitchToken &+= 1
                 }
                 selection = newValue

--- a/Hibi/ContentView.swift
+++ b/Hibi/ContentView.swift
@@ -13,6 +13,12 @@ struct ContentView: View {
     /// displayed date so switching tabs lands near where the previous tab
     /// was looking, instead of wherever each tab was last left.
     @State private var tabSwitchToken: Int = 0
+    /// (year, month) captured when the user enters the Month tab. On exit,
+    /// if the user scrolled Month to a different month, we anchor the
+    /// destination on day 1 (Month has no notion of a single "current day").
+    /// If they left Month on the same month they entered, selectedDay is
+    /// preserved so Day → Month → Day round-trips don't lose the day.
+    @State private var monthEntry: (year: Int, month: Int)?
     @State private var showSettings = false
     @State private var displayedYear = SampleData.todayYear
     @State private var displayedMonth = SampleData.todayMonth
@@ -37,13 +43,19 @@ struct ContentView: View {
                 if newValue == selection {
                     returnToNow()
                 } else {
-                    // Leaving the Month tab: anchor the destination on day 1
-                    // of the displayed month, since Month has no concept of
-                    // a single "current day" — landing on whatever
-                    // selectedDay happened to hold (often mid-month) is
-                    // arbitrary.
-                    if selection == .month {
+                    // Leaving Month: only anchor the destination on day 1 if
+                    // the user actually scrolled Month to a different month.
+                    // Otherwise they were just visiting and we preserve
+                    // selectedDay so Day → Month → Day stays on the same day.
+                    if selection == .month, let entry = monthEntry,
+                       entry.year != displayedYear || entry.month != displayedMonth {
                         selectedDay = 1
+                    }
+                    if selection == .month {
+                        monthEntry = nil
+                    }
+                    if newValue == .month {
+                        monthEntry = (displayedYear, displayedMonth)
                     }
                     tabSwitchToken &+= 1
                 }

--- a/Hibi/Views/MonthView.swift
+++ b/Hibi/Views/MonthView.swift
@@ -150,6 +150,7 @@ struct MonthsScrollView: View {
     @Binding var displayedYear: Int
     @Binding var displayedMonth: Int
     let scrollToNowToken: Int
+    let tabSwitchToken: Int
     var onPickDay: (Int, Int, Int) -> Void
 
     @State private var window: CalendarWindow
@@ -159,18 +160,19 @@ struct MonthsScrollView: View {
         displayedYear: Binding<Int>,
         displayedMonth: Binding<Int>,
         scrollToNowToken: Int,
+        tabSwitchToken: Int,
         onPickDay: @escaping (Int, Int, Int) -> Void
     ) {
         self._displayedYear = displayedYear
         self._displayedMonth = displayedMonth
         self.scrollToNowToken = scrollToNowToken
+        self.tabSwitchToken = tabSwitchToken
         self.onPickDay = onPickDay
-        // Seed on today, not the binding: the binding can drift when the Week
-        // view has been scrolled before the Month tab is first opened, which
-        // otherwise lands Month on whatever month Week was showing.
+        // Seed from the shared displayed date so opening Month after another
+        // tab scrolled lands close to where the user was looking.
         let seed = MonthKey(
-            year: SampleData.todayYear,
-            month: SampleData.todayMonth
+            year: displayedYear.wrappedValue,
+            month: displayedMonth.wrappedValue
         )
         _window = State(initialValue: CalendarWindow(center: seed))
         var initial = ScrollPosition(idType: Int.self)
@@ -221,6 +223,14 @@ struct MonthsScrollView: View {
             withAnimation(.snappy(duration: 0.35)) {
                 position.scrollTo(id: today.id)
             }
+        }
+        .onChange(of: tabSwitchToken) { _, _ in
+            // When the user switches into this tab, sync to the month the
+            // previous tab was showing. Snap (no animation) — the scroll
+            // happens behind the tab transition.
+            let target = MonthKey(year: displayedYear, month: displayedMonth)
+            window.recenter(on: target)
+            position.scrollTo(id: target.id)
         }
     }
 }

--- a/Hibi/Views/StreamView.swift
+++ b/Hibi/Views/StreamView.swift
@@ -19,7 +19,9 @@ struct DraggedEvent: Codable, Transferable {
 struct StreamView: View {
     @Binding var displayedYear: Int
     @Binding var displayedMonth: Int
+    @Binding var selectedDay: Int
     let scrollToNowToken: Int
+    let tabSwitchToken: Int
     let onPickDay: (Int, Int, Int) -> Void
     let onTapEvent: (CalendarEvent) -> Void
 
@@ -30,20 +32,29 @@ struct StreamView: View {
     init(
         displayedYear: Binding<Int>,
         displayedMonth: Binding<Int>,
+        selectedDay: Binding<Int>,
         scrollToNowToken: Int,
+        tabSwitchToken: Int,
         onPickDay: @escaping (Int, Int, Int) -> Void,
         onTapEvent: @escaping (CalendarEvent) -> Void
     ) {
         self._displayedYear = displayedYear
         self._displayedMonth = displayedMonth
+        self._selectedDay = selectedDay
         self.scrollToNowToken = scrollToNowToken
+        self.tabSwitchToken = tabSwitchToken
         self.onPickDay = onPickDay
         self.onTapEvent = onTapEvent
 
         let y = displayedYear.wrappedValue
         let m = displayedMonth.wrappedValue
-        let isTodayMonth = y == SampleData.todayYear && m == SampleData.todayMonth
-        let seedDay = isTodayMonth ? SampleData.todayDay : 15
+        // Clamp the selected day in case the displayed month has fewer days
+        // (e.g. selectedDay=31 from March, displayedMonth scrolled to April
+        // by Month tab).
+        let seedDay = min(
+            max(1, selectedDay.wrappedValue),
+            SampleData.daysInMonth(year: y, month: m)
+        )
         let seed = DayKey(year: y, month: m, day: seedDay)
         _window = State(initialValue: StreamWindow(center: seed))
         var initial = ScrollPosition(idType: Int.self)
@@ -94,8 +105,10 @@ struct StreamView: View {
             window.visibleDayID = newID
             let y = newID / 10_000
             let m = (newID / 100) % 100
+            let d = newID % 100
             if y != displayedYear { displayedYear = y }
             if m != displayedMonth { displayedMonth = m }
+            if d != selectedDay { selectedDay = d }
         }
         .onChange(of: scrollToNowToken) { _, _ in
             let today = DayKey(
@@ -107,6 +120,19 @@ struct StreamView: View {
             withAnimation(.snappy(duration: 0.35)) {
                 position.scrollTo(id: today.id)
             }
+        }
+        .onChange(of: tabSwitchToken) { _, _ in
+            // Sync to whichever day the previous tab was showing. Clamp the
+            // day in case it was set on a longer month than the one we're
+            // landing in. Snap (no animation) — the scroll happens behind
+            // the tab transition.
+            let safeDay = min(
+                max(1, selectedDay),
+                SampleData.daysInMonth(year: displayedYear, month: displayedMonth)
+            )
+            let target = DayKey(year: displayedYear, month: displayedMonth, day: safeDay)
+            window.recenter(on: target)
+            position.scrollTo(id: target.id)
         }
     }
 }

--- a/Hibi/Views/StreamView.swift
+++ b/Hibi/Views/StreamView.swift
@@ -58,7 +58,7 @@ struct StreamView: View {
         let seed = DayKey(year: y, month: m, day: seedDay)
         _window = State(initialValue: StreamWindow(center: seed))
         var initial = ScrollPosition(idType: Int.self)
-        initial.scrollTo(id: seed.id, anchor: .center)
+        initial.scrollTo(id: seed.id, anchor: .top)
         _position = State(initialValue: initial)
     }
 
@@ -91,7 +91,7 @@ struct StreamView: View {
             .padding(.top, 4)
             .padding(.bottom, 160)
         }
-        .scrollPosition($position, anchor: .center)
+        .scrollPosition($position, anchor: .top)
         .scrollTargetBehavior(.viewAligned)
         .sensoryFeedback(.selection, trigger: position.viewID(type: Int.self))
         .onScrollPhaseChange { _, newPhase in


### PR DESCRIPTION
## Summary
This PR improves the tab switching experience by synchronizing the scroll position across different calendar views. When users switch between tabs, the new tab now scrolls to show the same month/day that was visible in the previous tab, rather than jumping to a previously cached position.

## Key Changes
- **ContentView**: Added `tabSwitchToken` state that increments whenever the user switches tabs (unless tapping the same tab twice to return to now)
- **StreamView (Week view)**: 
  - Added `selectedDay` binding to track the currently displayed day
  - Added `tabSwitchToken` parameter to observe tab switches
  - Implemented day clamping logic to handle month transitions (e.g., when March 31st is selected but user scrolls to April)
  - Added `onChange` handler for `tabSwitchToken` to recenter the scroll position on the shared displayed date
- **MonthsScrollView (Month view)**:
  - Added `tabSwitchToken` parameter to observe tab switches
  - Changed initialization to seed from the shared `displayedYear`/`displayedMonth` bindings instead of always starting from today
  - Added `onChange` handler for `tabSwitchToken` to recenter the scroll position on the shared displayed date
- **Shared state**: `displayedYear` and `displayedMonth` are now the source of truth for the currently viewed month across all tabs

## Implementation Details
- Tab switches trigger a snap scroll (no animation) since the transition happens behind the tab UI
- Day values are clamped to valid ranges when switching months to prevent invalid dates (e.g., February 31st)
- The `tabSwitchToken` uses wrapping addition (`&+=`) to avoid overflow issues with repeated increments

https://claude.ai/code/session_01Hi1d5aGWzSeBnNuQUegGs8