### PR TITLE
Add draggable schedule separator with collapse animation

### DIFF
--- a/Hibi/Views/Components/DayEventRow.swift
+++ b/Hibi/Views/Components/DayEventRow.swift
@@ -35,11 +35,23 @@ struct DayEventRow: View {
         // Two stacked backgrounds: the progress fill sits above the base tint,
         // so the row shows a subtle category color by default and darkens
         // left-to-right as the event elapses.
+        //
+        // The progress fill is a full-width Rectangle scaled horizontally
+        // via .scaleEffect. The earlier implementation used a GeometryReader
+        // that read its container's width and sized the fill to a fraction
+        // of it — that's the classic GeometryReader-in-background pattern
+        // Apple flagged in WWDC23's "Demystify SwiftUI performance" and
+        // replaced with onGeometryChange. With many rows in a ScrollView
+        // whose container resizes per-frame (the schedule-collapse drag),
+        // each row's GR re-reports geometry in a follow-up layout pass,
+        // those passes converge over ~10-20 frames, and the convergence is
+        // what surfaces as flicker mid-drag and a smooth "settle" when the
+        // finger stops. scaleEffect is a render-time transform — no layout
+        // pass, no async geometry, pixel-identical visual.
         .background(alignment: .leading) {
-            GeometryReader { geo in
-                event.tint.opacity(event.allDay ? 0.28 : 0.26)
-                    .frame(width: geo.size.width * CGFloat(fillAmount))
-            }
+            Rectangle()
+                .fill(event.tint.opacity(event.allDay ? 0.28 : 0.26))
+                .scaleEffect(x: CGFloat(fillAmount), y: 1, anchor: .leading)
         }
         .background(event.tint.opacity(event.allDay ? 0.38 : 0.10))
         .clipShape(RoundedRectangle(cornerRadius: 12))

--- a/Hibi/Views/DayView.swift
+++ b/Hibi/Views/DayView.swift
@@ -452,7 +452,19 @@ struct DayView: View {
                 let raw = scheduleDragBaseProgress + delta
                 let clamped = max(0, min(1, raw))
                 if clamped != scheduleProgress {
-                    withTransaction(\.scrollContentOffsetAdjustmentBehavior, .disabled) {
+                    // Per-frame writes must be (a) un-animated and (b) must
+                    // not let the ScrollView animate its content offset for
+                    // the resulting container resize. Setting both flags
+                    // explicitly defends against an ambient animation
+                    // context being inherited from an ancestor (TabView /
+                    // NavigationStack iOS-26 transitions do wrap content in
+                    // animated transactions, and value-scoped .animation
+                    // modifiers elsewhere in the tree could otherwise
+                    // re-bind to our Animatable padding/frame writes).
+                    var t = Transaction()
+                    t.disablesAnimations = true
+                    t.scrollContentOffsetAdjustmentBehavior = .disabled
+                    withTransaction(t) {
                         scheduleProgress = clamped
                     }
                 }

--- a/Hibi/Views/DayView.swift
+++ b/Hibi/Views/DayView.swift
@@ -87,6 +87,12 @@ struct DayView: View {
             }
             .scrollIndicators(.hidden)
             .scrollBounceBehavior(.basedOnSize)
+            // Pin the content's top edge when the ScrollView's own frame
+            // grows/shrinks as the schedule separator collapses. The default
+            // anchor tries to keep the visible centroid stable, which during
+            // a drag means the list animates its offset to compensate — the
+            // source of the flicker the user saw on slow drags.
+            .defaultScrollAnchor(.top, for: .sizeChanges)
             .mask(scrollFadeMask)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
@@ -421,6 +427,16 @@ struct DayView: View {
     /// a single spring animation. We use velocity to bias the snap target —
     /// a quick flick commits even from below the halfway point, matching
     /// iOS sheet behavior.
+    ///
+    /// Every write to `scheduleProgress` propagates inside a transaction
+    /// that sets `scrollContentOffsetAdjustmentBehavior = .disabled`. The
+    /// schedule list's ScrollView would otherwise treat each per-frame
+    /// growth of its container as a reason to animate its own content
+    /// offset (UIScrollView-style deceleration), which surfaces as flicker
+    /// during slow drags — and as the characteristic "settle" after the
+    /// finger stops. Pair that with `.defaultScrollAnchor(.top, for:
+    /// .sizeChanges)` on the ScrollView so any residual adjustment pins
+    /// the content's top edge rather than its visible centroid.
     private var scheduleDragGesture: some Gesture {
         // .global so translation tracks the finger in screen space — the
         // separator's own layout position shifts up as scheduleProgress
@@ -436,7 +452,9 @@ struct DayView: View {
                 let raw = scheduleDragBaseProgress + delta
                 let clamped = max(0, min(1, raw))
                 if clamped != scheduleProgress {
-                    scheduleProgress = clamped
+                    withTransaction(\.scrollContentOffsetAdjustmentBehavior, .disabled) {
+                        scheduleProgress = clamped
+                    }
                 }
             }
             .onEnded { value in
@@ -450,7 +468,10 @@ struct DayView: View {
                 if target != scheduleProgress {
                     scheduleSnapCount &+= 1
                 }
-                withAnimation(.spring(response: 0.38, dampingFraction: 0.86)) {
+                var t = Transaction()
+                t.animation = .spring(response: 0.38, dampingFraction: 0.86)
+                t.scrollContentOffsetAdjustmentBehavior = .disabled
+                withTransaction(t) {
                     scheduleProgress = target
                 }
             }

--- a/Hibi/Views/DayView.swift
+++ b/Hibi/Views/DayView.swift
@@ -432,7 +432,6 @@ struct DayView: View {
         .sensoryFeedback(.impact(weight: .light, intensity: 0.6), trigger: scheduleSnapCount)
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(Text("Schedule"))
-        .accessibilityAddTraits(.isAdjustable)
     }
 
     /// One side of the handle: a serif tick at the outer edge + a hairline

--- a/Hibi/Views/DayView.swift
+++ b/Hibi/Views/DayView.swift
@@ -56,13 +56,19 @@ struct DayView: View {
     private let offScreen: CGFloat = 700
 
     // Schedule-collapse geometry. The paper stack and the "Pull to tear" hint
-    // shrink toward `…Collapsed` values as scheduleProgress → 1. Drag range is
-    // tuned to match the total visual displacement so the finger and the
+    // shrink toward `…Collapsed` values as scheduleProgress → 1. Drag range
+    // is tuned to match the total visual displacement so the finger and the
     // separator move at roughly 1:1.
+    //
+    // `paperHeightCollapsed` is the floor for the paper-stack height; on top
+    // of it the hint row contributes 36pt of additional collapse. Together
+    // they place the schedule separator near the vertical center of the
+    // screen at maximum collapse (the spec's stop position — "don't let it
+    // go all the way to the top"). 380→260 + 36→0 ≈ 156pt of upward travel.
     private let paperHeightExpanded: CGFloat = 380
-    private let paperHeightCollapsed: CGFloat = 150
+    private let paperHeightCollapsed: CGFloat = 260
     private let hintHeightExpanded: CGFloat = 36
-    private let scheduleDragRange: CGFloat = 260
+    private let scheduleDragRange: CGFloat = 160
 
     // Progressive paper tints — white → off-white → beige (depth cue).
     private let card1Fill = PaperTints.card1

--- a/Hibi/Views/DayView.swift
+++ b/Hibi/Views/DayView.swift
@@ -412,19 +412,42 @@ struct DayView: View {
 
     // MARK: - Schedule
 
+    /// Drag handle that replaces the old "Schedule" label. The bracketed
+    /// hairlines + small center pill read as a typographic separator
+    /// (think editorial dingbat) rather than an iOS drawer grabber, which
+    /// matches the rest of the app's paper-and-serif aesthetic. Outer
+    /// vertical ticks are the "serif" ends the user asked for.
     private var scheduleHeader: some View {
-        HStack(spacing: 10) {
-            Rectangle().fill(.quaternary).frame(height: 0.5)
-            Text("Schedule")
-                .font(.system(size: 10, weight: .semibold))
-                .tracking(2.2)
-                .foregroundStyle(.secondary)
-            Rectangle().fill(.quaternary).frame(height: 0.5)
+        HStack(spacing: 8) {
+            scheduleHandleArm(leading: true)
+            Capsule()
+                .fill(.tertiary)
+                .frame(width: 28, height: 4)
+            scheduleHandleArm(leading: false)
         }
+        .frame(maxWidth: .infinity)
         .padding(.vertical, 12)              // generous vertical hit area
         .contentShape(Rectangle())           // entire row receives the drag
         .gesture(scheduleDragGesture)
         .sensoryFeedback(.impact(weight: .light, intensity: 0.6), trigger: scheduleSnapCount)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(Text("Schedule"))
+        .accessibilityAddTraits(.isAdjustable)
+    }
+
+    /// One side of the handle: a serif tick at the outer edge + a hairline
+    /// running in to the center pill. The tick anchors the line visually
+    /// the way a small bracket anchors a typographic rule.
+    private func scheduleHandleArm(leading: Bool) -> some View {
+        HStack(spacing: 0) {
+            if leading {
+                Rectangle().fill(.quaternary).frame(width: 1, height: 5)
+                Rectangle().fill(.quaternary).frame(height: 0.5)
+            } else {
+                Rectangle().fill(.quaternary).frame(height: 0.5)
+                Rectangle().fill(.quaternary).frame(width: 1, height: 5)
+            }
+        }
     }
 
     /// Vertical drag on the schedule separator. Drives `scheduleProgress`

--- a/Hibi/Views/DayView.swift
+++ b/Hibi/Views/DayView.swift
@@ -28,12 +28,41 @@ struct DayView: View {
     @State private var incomingCardY: CGFloat = -400   // off-screen above for backward tear
     @State private var scheduleSlideY: CGFloat = 0     // slide-up offset for schedule fade-in
 
+    // MARK: - Schedule separator drag
+    //
+    // Single source of truth for the draggable Schedule separator. All visual
+    // responses (paper height, aspect-ratio inset, chrome fade, hint collapse)
+    // derive deterministically from `scheduleProgress` so they animate in
+    // lockstep inside one transaction — that's what keeps a slow drag flicker-
+    // free. During drag the gesture writes scheduleProgress directly (no
+    // withAnimation); on release a single withAnimation(.spring) drives the
+    // magnetic snap.
+
+    /// 0 = paper stack at full size (default); 1 = collapsed, events list expanded.
+    @State private var scheduleProgress: CGFloat = 0
+    /// Progress at the moment the current drag began. Translation is applied
+    /// relative to this so the separator tracks the finger 1:1.
+    @State private var scheduleDragBaseProgress: CGFloat = 0
+    /// True while a finger is on the separator.
+    @State private var isDraggingSchedule: Bool = false
+    /// Tick for haptic on snap.
+    @State private var scheduleSnapCount: Int = 0
+
     // MARK: - Layout constants
 
     private let peekAmount: CGFloat = 10      // pts each card behind peeks below the one in front
     private let narrowStep: CGFloat = 14      // pts narrower per side per depth level
     private let tearThreshold: CGFloat = 80
     private let offScreen: CGFloat = 700
+
+    // Schedule-collapse geometry. The paper stack and the "Pull to tear" hint
+    // shrink toward `…Collapsed` values as scheduleProgress → 1. Drag range is
+    // tuned to match the total visual displacement so the finger and the
+    // separator move at roughly 1:1.
+    private let paperHeightExpanded: CGFloat = 380
+    private let paperHeightCollapsed: CGFloat = 150
+    private let hintHeightExpanded: CGFloat = 36
+    private let scheduleDragRange: CGFloat = 260
 
     // Progressive paper tints — white → off-white → beige (depth cue).
     private let card1Fill = PaperTints.card1
@@ -100,6 +129,39 @@ struct DayView: View {
         return 1 - min(Double(abs(dragY)) / tearThreshold, 1)
     }
 
+    // MARK: - Schedule-collapse derived values
+
+    /// Dynamic paper stack height. Interpolates expanded → collapsed.
+    private var paperHeight: CGFloat {
+        paperHeightExpanded + (paperHeightCollapsed - paperHeightExpanded) * scheduleProgress
+    }
+
+    /// Dynamic height for the "Pull to tear" hint row. Collapses to 0 as the
+    /// stack collapses so the schedule header moves up rather than just fading.
+    private var hintHeight: CGFloat {
+        hintHeightExpanded * (1 - scheduleProgress)
+    }
+
+    /// 0…1 fade for paper-card chrome that should disappear when collapsed:
+    /// sunrise/sunset, weather pill, Apple Weather attribution, and the
+    /// month/year sub-text. The big day number, weekday, and today underline
+    /// remain at full opacity. A slight overshoot (1.25) makes chrome reach
+    /// fully invisible well before the snap completes, which reads cleaner
+    /// than a linear fade.
+    private var chromeFadeOpacity: Double {
+        Double(max(0, 1 - scheduleProgress * 1.25))
+    }
+
+    /// Horizontal inset (per side) added to each paper card to keep its
+    /// aspect ratio constant as the stack height shrinks. Computed from the
+    /// container width inside the tearStack's GeometryReader.
+    private func paperShrinkInset(containerWidth: CGFloat) -> CGFloat {
+        guard scheduleProgress > 0 else { return 0 }
+        let scale = paperHeight / paperHeightExpanded
+        let amount = containerWidth * (1 - scale) / 2
+        return max(0, amount)
+    }
+
     private var pullToTearHint: some View {
         Text(invertDaySwipe
              ? "Pull to tear · ↑ Prev · ↓ Next"
@@ -108,8 +170,9 @@ struct DayView: View {
             .tracking(1.2)
             .foregroundStyle(.secondary.opacity(0.6))
             .frame(maxWidth: .infinity)
-            .frame(height: 36)
-            .opacity(tearHintOpacity)
+            .frame(height: hintHeight, alignment: .center)
+            .opacity(tearHintOpacity * chromeFadeOpacity)
+            .clipped()
             .animation(.easeOut(duration: 0.32), value: isTearing)
     }
 
@@ -138,9 +201,13 @@ struct DayView: View {
 
     private var tearStack: some View {
         GeometryReader { geo in
-            let maxH: CGFloat = min(geo.size.height, 380)
+            let maxH: CGFloat = min(geo.size.height, paperHeightExpanded)
             let width = geo.size.width
             let goingForward = tearDirection == 1
+            // Per-card inset that preserves the paper's aspect ratio as the
+            // stack shrinks vertically. Computed once per geometry change so
+            // every card in the stack moves in unison.
+            let aspectInset = paperShrinkInset(containerWidth: width)
 
             ZStack(alignment: .top) {
                 // --- Deepest placeholder (forward tear only) ---
@@ -151,7 +218,7 @@ struct DayView: View {
                     baseFill: card3Fill,
                     overlayFill: card3Fill,
                     overlayOpacity: 0,
-                    horizontalInset: narrowStep * 2,
+                    horizontalInset: aspectInset + narrowStep * 2,
                     bottomPeek: 0,
                     shadowAmount: 0,
                     chromeAmount: 0
@@ -166,9 +233,9 @@ struct DayView: View {
                     baseFill: card3Fill,
                     overlayFill: card2Fill,
                     overlayOpacity: goingForward ? cardShiftAmount : 0,
-                    horizontalInset: goingForward
+                    horizontalInset: aspectInset + (goingForward
                         ? narrowStep * (2 - cardShiftAmount)
-                        : narrowStep * 2,
+                        : narrowStep * 2),
                     bottomPeek: goingForward ? peekAmount * cardShiftAmount : 0,
                     shadowAmount: 0,
                     chromeAmount: 0
@@ -183,9 +250,9 @@ struct DayView: View {
                     baseFill: card2Fill,
                     overlayFill: goingForward ? card1Fill : card3Fill,
                     overlayOpacity: cardShiftAmount,
-                    horizontalInset: goingForward
+                    horizontalInset: aspectInset + (goingForward
                         ? narrowStep * (1 - cardShiftAmount)
-                        : narrowStep * (1 + cardShiftAmount),
+                        : narrowStep * (1 + cardShiftAmount)),
                     bottomPeek: goingForward
                         ? peekAmount * (1 + cardShiftAmount)
                         : peekAmount * (1 - cardShiftAmount),
@@ -202,7 +269,7 @@ struct DayView: View {
                     baseFill: card1Fill,
                     overlayFill: goingForward ? card1Fill : card2Fill,
                     overlayOpacity: goingForward ? 0 : cardShiftAmount,
-                    horizontalInset: goingForward ? 0 : narrowStep * cardShiftAmount,
+                    horizontalInset: aspectInset + (goingForward ? 0 : narrowStep * cardShiftAmount),
                     bottomPeek: goingForward
                         ? peekAmount * 2
                         : peekAmount * (2 - cardShiftAmount),
@@ -247,7 +314,7 @@ struct DayView: View {
                 baseFill: card1Fill,
                 overlayFill: card1Fill,
                 overlayOpacity: 0,
-                horizontalInset: 0,
+                horizontalInset: aspectInset,
                 bottomPeek: peekAmount * 2,
                 shadowAmount: 1,
                 chromeAmount: 1
@@ -260,7 +327,7 @@ struct DayView: View {
             .opacity(max(0, 1 - abs(incomingCardY) / 400))
             .allowsHitTesting(false)
         }
-        .frame(height: 380)
+        .frame(height: paperHeight)
     }
 
     // MARK: - Paper card builder
@@ -308,7 +375,8 @@ struct DayView: View {
                     isToday: isToday,
                     weather: weather,
                     locationName: weatherStore.locationName,
-                    preview: chromeAmount < 1
+                    preview: chromeAmount < 1,
+                    chromeFade: Double(1 - scheduleProgress)
                 )
                 .allowsHitTesting(false)
             }
@@ -341,8 +409,51 @@ struct DayView: View {
                 .foregroundStyle(.secondary)
             Rectangle().fill(.quaternary).frame(height: 0.5)
         }
-        .padding(.bottom, 10)
-        .padding(.top, 4)
+        .padding(.vertical, 12)              // generous vertical hit area
+        .contentShape(Rectangle())           // entire row receives the drag
+        .gesture(scheduleDragGesture)
+        .sensoryFeedback(.impact(weight: .light, intensity: 0.6), trigger: scheduleSnapCount)
+    }
+
+    /// Vertical drag on the schedule separator. Drives `scheduleProgress`
+    /// directly during the drag (no animation, follows the finger), then on
+    /// release snaps to whichever end (0 or 1) the user is closer to inside
+    /// a single spring animation. We use velocity to bias the snap target —
+    /// a quick flick commits even from below the halfway point, matching
+    /// iOS sheet behavior.
+    private var scheduleDragGesture: some Gesture {
+        // .global so translation tracks the finger in screen space — the
+        // separator's own layout position shifts up as scheduleProgress
+        // grows, which would skew .local translation and cause feedback.
+        DragGesture(minimumDistance: 4, coordinateSpace: .global)
+            .onChanged { value in
+                if !isDraggingSchedule {
+                    scheduleDragBaseProgress = scheduleProgress
+                    isDraggingSchedule = true
+                }
+                // Up-translation is negative; up increases progress (collapses).
+                let delta = -value.translation.height / scheduleDragRange
+                let raw = scheduleDragBaseProgress + delta
+                let clamped = max(0, min(1, raw))
+                if clamped != scheduleProgress {
+                    scheduleProgress = clamped
+                }
+            }
+            .onEnded { value in
+                isDraggingSchedule = false
+                // Predict where the gesture would land if momentum continued —
+                // the same heuristic UISheetPresentationController uses.
+                let predicted = value.predictedEndTranslation.height
+                let predictedDelta = -predicted / scheduleDragRange
+                let projected = scheduleDragBaseProgress + predictedDelta
+                let target: CGFloat = projected >= 0.5 ? 1 : 0
+                if target != scheduleProgress {
+                    scheduleSnapCount &+= 1
+                }
+                withAnimation(.spring(response: 0.38, dampingFraction: 0.86)) {
+                    scheduleProgress = target
+                }
+            }
     }
 
     private var scheduleEvents: some View {
@@ -572,6 +683,13 @@ private struct PageContent: View {
     let weather: DayWeather?
     let locationName: String?
     let preview: Bool
+    /// 1.0 = paper expanded (full corner widgets); 0.0 = collapsed via the
+    /// schedule separator drag. Multiplies the opacity of the sunrise/sunset
+    /// widgets, weather pill, Apple Weather attribution, and month/year
+    /// sub-text — and collapses their reserved height so the central numeral
+    /// block keeps its breathing room as the card shrinks. The weekday, day
+    /// number, and today underline are not faded.
+    var chromeFade: Double = 1.0
 
     @AppStorage("useSimpleFont") private var useSimpleFont: Bool = false
     @AppStorage(TimeFormat.defaultsKey) private var timeFormatRaw: String = TimeFormat.system.rawValue
@@ -594,8 +712,8 @@ private struct PageContent: View {
             bottomRow
         }
         .padding(.horizontal, 22)
-        .padding(.top, 34)
-        .padding(.bottom, 20)
+        .padding(.top, 34 * chromeFade + 12 * (1 - chromeFade))
+        .padding(.bottom, 20 * chromeFade + 8 * (1 - chromeFade))
     }
 
     private var topRow: some View {
@@ -609,7 +727,7 @@ private struct PageContent: View {
                     .tracking(0.6)
                     .foregroundStyle(.secondary)
             }
-            .opacity(weather?.sunrise == nil ? 0 : 1)
+            .opacity(weather?.sunrise == nil ? 0 : chromeFade)
             Spacer()
             Text(DayNames.full[SampleData.weekday(year: year, month: month, day: day)])
                 .font(.appSerif(size: 19, italic: true, simple: useSimpleFont))
@@ -625,9 +743,13 @@ private struct PageContent: View {
                     .tracking(0.6)
                     .foregroundStyle(.secondary)
             }
-            .opacity(weather?.sunset == nil ? 0 : 1)
+            .opacity(weather?.sunset == nil ? 0 : chromeFade)
         }
-        .frame(height: 44)
+        // Don't collapse all the way to 0 — the weekday text in the center
+        // is a "stays" element per the schedule-collapse spec. Floor at the
+        // weekday's own intrinsic height so it remains visible.
+        .frame(height: 44 * chromeFade + 24 * (1 - chromeFade))
+        .clipped()
     }
 
     private var numeralBlock: some View {
@@ -655,7 +777,9 @@ private struct PageContent: View {
                 .font(.appSerif(size: 13, italic: true, simple: useSimpleFont))
                 .foregroundStyle(.secondary)
                 .padding(.top, 2)
-                .frame(height: 18)
+                .frame(height: 18 * chromeFade)
+                .opacity(chromeFade)
+                .clipped()
         }
         .frame(maxWidth: .infinity)
     }
@@ -689,7 +813,9 @@ private struct PageContent: View {
             AppleWeatherAttribution()
                 .opacity(weather == nil ? 0 : 1)
         }
-        .frame(height: 56)
+        .frame(height: 56 * chromeFade)
+        .opacity(chromeFade)
+        .clipped()
     }
 }
 

--- a/Hibi/Views/DayView.swift
+++ b/Hibi/Views/DayView.swift
@@ -412,20 +412,21 @@ struct DayView: View {
 
     // MARK: - Schedule
 
-    /// Minimal drag handle — just a centered pill. No flanking lines or
-    /// serif caps for now; the gesture and snap motion communicate the
-    /// affordance.
+    /// Centered pill handle flanked by hairlines that run out to the edges.
     private var scheduleHeader: some View {
-        Capsule()
-            .fill(.tertiary)
-            .frame(width: 36, height: 5)
-            .frame(maxWidth: .infinity)
-            .padding(.vertical, 12)              // generous vertical hit area
-            .contentShape(Rectangle())           // entire row receives the drag
-            .gesture(scheduleDragGesture)
-            .sensoryFeedback(.impact(weight: .light, intensity: 0.6), trigger: scheduleSnapCount)
-            .accessibilityElement(children: .ignore)
-            .accessibilityLabel(Text("Schedule"))
+        HStack(spacing: 10) {
+            Rectangle().fill(.quaternary).frame(height: 0.5)
+            Capsule()
+                .fill(.tertiary)
+                .frame(width: 36, height: 5)
+            Rectangle().fill(.quaternary).frame(height: 0.5)
+        }
+        .padding(.vertical, 12)              // generous vertical hit area
+        .contentShape(Rectangle())           // entire row receives the drag
+        .gesture(scheduleDragGesture)
+        .sensoryFeedback(.impact(weight: .light, intensity: 0.6), trigger: scheduleSnapCount)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(Text("Schedule"))
     }
 
     /// Vertical drag on the schedule separator. Drives `scheduleProgress`

--- a/Hibi/Views/DayView.swift
+++ b/Hibi/Views/DayView.swift
@@ -412,41 +412,20 @@ struct DayView: View {
 
     // MARK: - Schedule
 
-    /// Drag handle that replaces the old "Schedule" label. The bracketed
-    /// hairlines + small center pill read as a typographic separator
-    /// (think editorial dingbat) rather than an iOS drawer grabber, which
-    /// matches the rest of the app's paper-and-serif aesthetic. Outer
-    /// vertical ticks are the "serif" ends the user asked for.
+    /// Minimal drag handle — just a centered pill. No flanking lines or
+    /// serif caps for now; the gesture and snap motion communicate the
+    /// affordance.
     private var scheduleHeader: some View {
-        HStack(spacing: 8) {
-            scheduleHandleArm(leading: true)
-            Capsule()
-                .fill(.tertiary)
-                .frame(width: 28, height: 4)
-            scheduleHandleArm(leading: false)
-        }
-        .frame(maxWidth: .infinity)
-        .padding(.vertical, 12)              // generous vertical hit area
-        .contentShape(Rectangle())           // entire row receives the drag
-        .gesture(scheduleDragGesture)
-        .sensoryFeedback(.impact(weight: .light, intensity: 0.6), trigger: scheduleSnapCount)
-        .accessibilityElement(children: .ignore)
-        .accessibilityLabel(Text("Schedule"))
-    }
-
-    /// One side of the handle: a serif tick at the outer edge + a hairline
-    /// running in to the center pill. The tick anchors the line visually
-    /// the way a small bracket anchors a typographic rule.
-    private func scheduleHandleArm(leading: Bool) -> some View {
-        HStack(spacing: 0) {
-            if leading {
-                Rectangle().fill(.quaternary).frame(width: 1, height: 5)
-                Rectangle().fill(.quaternary).frame(height: 0.5)
-            } else {
-                Rectangle().fill(.quaternary).frame(height: 0.5)
-                Rectangle().fill(.quaternary).frame(width: 1, height: 5)
-            }
-        }
+        Capsule()
+            .fill(.tertiary)
+            .frame(width: 36, height: 5)
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 12)              // generous vertical hit area
+            .contentShape(Rectangle())           // entire row receives the drag
+            .gesture(scheduleDragGesture)
+            .sensoryFeedback(.impact(weight: .light, intensity: 0.6), trigger: scheduleSnapCount)
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel(Text("Schedule"))
     }
 
     /// Vertical drag on the schedule separator. Drives `scheduleProgress`

--- a/Hibi/Views/DayView.swift
+++ b/Hibi/Views/DayView.swift
@@ -750,9 +750,15 @@ private struct PageContent: View {
             Spacer(minLength: 0)
             bottomRow
         }
+        // Keep the page's inner padding constant across the schedule
+        // collapse — the weekday/numeral/underline are "stays" elements and
+        // need to sit at their original distance from the binding holes /
+        // perforation edge regardless of card height. The numeral block has
+        // plenty of room at the collapsed height (260 - 34 - 20 = 206pt
+        // inner area is more than the day number's intrinsic ~180pt).
         .padding(.horizontal, 22)
-        .padding(.top, 34 * chromeFade + 12 * (1 - chromeFade))
-        .padding(.bottom, 20 * chromeFade + 8 * (1 - chromeFade))
+        .padding(.top, 34)
+        .padding(.bottom, 20)
     }
 
     private var topRow: some View {

--- a/learnings.md
+++ b/learnings.md
@@ -68,6 +68,48 @@ window.extendIfNearEdge(visibleID: id)
 - **`scrollPosition(id: $scrollTarget)` binding for programmatic scroll**: race-prone when data and position update in the same tick; no-op when binding value hasn't changed.
 - **`defaultScrollAnchor(.center)` for "start on today"**: imprecise with lazy, variable-height content.
 
+## `GeometryReader` inside `.background` causes flicker when the container resizes per-frame
+
+**Symptom we hit:** the draggable Schedule separator in `DayView` flickered heavily during slow drags. Both the paper stack *and* the events list rows rippled. When the user stopped moving but kept their finger down, the flicker would **smoothly settle over ~10-20 frames** — not snap. That settling pattern is the signature.
+
+**Cause:** every `DayEventRow` had a progress fill drawn with this pattern:
+
+```swift
+.background(alignment: .leading) {
+    GeometryReader { geo in
+        event.tint.opacity(...)
+            .frame(width: geo.size.width * CGFloat(fillAmount))
+    }
+}
+```
+
+`GeometryReader` reports geometry in a **follow-up layout pass**, not synchronously. When a drag resizes the ScrollView's container 60×/sec, every row's GR re-reports its width in an async pass, that triggers another layout pass, which the GR republishes again. The system iterates toward convergence over many frames — visible as flicker mid-drag and as a deceleration-style settle when input stops. Apple flagged this in WWDC23 *Demystify SwiftUI performance* and shipped `onGeometryChange` (iOS 18) as the replacement.
+
+A second-order contributor was the gesture transaction inheriting an ambient animation context (TabView / NavigationStack iOS-26 transitions wrap their content in animated transactions). Without `t.disablesAnimations = true` on the per-frame writes, `Animatable` `.padding` / `.frame` modifiers got re-bound to that inherited animation.
+
+**Fix.** For fractional-width fills, use `.scaleEffect` on a full-width `Rectangle`:
+
+```swift
+.background(alignment: .leading) {
+    Rectangle()
+        .fill(event.tint.opacity(...))
+        .scaleEffect(x: CGFloat(fillAmount), y: 1, anchor: .leading)
+}
+```
+
+`scaleEffect` is a render-time transform — no layout pass, no async geometry, pixel-identical visual. For any per-frame state write driving layout (gestures, animation drivers), also set both flags on the transaction:
+
+```swift
+var t = Transaction()
+t.disablesAnimations = true
+t.scrollContentOffsetAdjustmentBehavior = .disabled   // iOS 18+
+withTransaction(t) { state = newValue }
+```
+
+The scroll-offset flag stops a `ScrollView` from animating its own content offset when its container size changes; the disabled-animations flag stops inherited animation contexts from re-binding to our writes. Both are needed when the per-frame write resizes a `ScrollView`'s container.
+
+**Diagnostic heuristic.** If a slow drag flickers and the flicker *smooths out over a fraction of a second* when input stops, suspect an async-layout convergence loop — almost always a `GeometryReader` placed where a fractional `.frame` or `.padding` could be a `.scaleEffect` instead. Value-scoped `.animation(_:value:)` modifiers are a red herring here: they only fire when *their* value changes, not when neighboring layout changes.
+
 ## Reference: the research brief
 
 The full background on why SwiftUI infinite scrolling is structurally hard (vs. `UICollectionView`), and why HorizonCalendar (UIKit) beats any pure-SwiftUI implementation for flat memory over decades of scroll, is in the original deep-research document — ask the user for it if needed. Hibi's approach is the "90% solution" sliding-window pattern it recommends.


### PR DESCRIPTION
## Summary
Implements a draggable schedule separator that collapses the paper card stack and expands the events list. The separator responds to vertical drag gestures with 1:1 finger tracking, snaps to fully expanded or collapsed states on release, and animates all dependent UI (card height, chrome fade, hint collapse) in lockstep to avoid flicker.

## Key Changes

**Schedule Separator Drag Gesture**
- Added `scheduleProgress` state (0 = expanded, 1 = collapsed) as the single source of truth
- Implemented `scheduleDragGesture` that writes `scheduleProgress` directly during drag (no animation) and snaps via spring animation on release
- Uses velocity-biased snap targeting to match iOS sheet behavior (quick flick commits even from below halfway point)
- Transaction flags (`disablesAnimations = true`, `scrollContentOffsetAdjustmentBehavior = .disabled`) prevent inherited animation contexts and ScrollView content-offset animation during per-frame writes

**Derived Layout Values**
- `paperHeight`: interpolates between expanded (380pt) and collapsed (260pt) states
- `hintHeight`: collapses the "Pull to tear" hint row to 0 as schedule collapses
- `chromeFadeOpacity`: fades sunrise/sunset widgets, weather pill, and attribution (1.25× overshoot for cleaner visual)
- `paperShrinkInset()`: maintains card aspect ratio as stack height shrinks

**Visual Updates**
- Schedule header redesigned as a centered pill handle with flanking hairlines; entire row is now the drag target
- Added `.defaultScrollAnchor(.top, for: .sizeChanges)` to schedule ScrollView to pin content's top edge during container resize
- `PageContent` now accepts `chromeFade` parameter to fade and collapse chrome elements proportionally
- Top row (sunrise/sunset), numeral block sub-text, and weather attribution all respond to `chromeFade`

**Bug Fix: GeometryReader Flicker**
- Replaced `GeometryReader` pattern in `DayEventRow` progress fill with `.scaleEffect` on a full-width `Rectangle`
- GeometryReader was causing async layout convergence loops during per-frame container resizes, surfacing as flicker mid-drag and smooth "settle" when input stopped
- Added detailed learning note documenting the symptom, cause, and diagnostic heuristic

## Implementation Details

The drag range (160pt) is tuned so the separator moves 1:1 with the finger. The paper stack shrinks 120pt (380→260) and the hint row contributes 36pt of additional collapse, totaling ~156pt of upward travel. Horizontal inset is computed per-frame inside the `tearStack` GeometryReader to keep all cards in the stack moving in unison as the aspect ratio adjusts.

All visual responses (height, opacity, inset) derive deterministically from `scheduleProgress` within a single transaction, keeping animations flicker-free during slow drags.

https://claude.ai/code/session_011qA6CHsQ4aZJtmAj1igGPh