### PR TITLE
Move opacity/offset modifiers outside HijackingScrollView

### DIFF
--- a/Hibi/Views/DayView.swift
+++ b/Hibi/Views/DayView.swift
@@ -95,6 +95,16 @@ struct DayView: View {
                     .padding(.top, 28)
                     .padding(.bottom, 140)
             }
+            // Opacity + slide are applied OUTSIDE the HijackingScrollView so
+            // withAnimation transactions resolve in the native SwiftUI tree.
+            // When these modifiers lived inside the closure they sat on the
+            // hosted content of a UIHostingController, and the animation
+            // context didn't propagate across that UIKit boundary — the
+            // tear-time fade was a hard cut, and interrupted animations
+            // could leave the events stuck at a mid-fade opacity (~0.5) until
+            // the app was restarted.
+            .opacity(eventsOpacity)
+            .offset(y: scheduleSlideY)
             .mask(scrollFadeMask)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
@@ -537,8 +547,6 @@ struct DayView: View {
                 }
             }
         }
-        .opacity(eventsOpacity)
-        .offset(y: scheduleSlideY)
     }
 
 


### PR DESCRIPTION
## Summary
Relocates the `.opacity()` and `.offset()` modifiers from inside the `HijackingScrollView` closure to the outer SwiftUI view tree. This ensures animation transactions resolve in the native SwiftUI context rather than within a UIHostingController boundary.

## Key Changes
- Moved `.opacity(eventsOpacity)` and `.offset(y: scheduleSlideY)` modifiers from the end of the scroll view's hosted content to the outer view hierarchy
- Positioned these modifiers between the scroll view and the `.mask(scrollFadeMask)` modifier
- Added detailed comment explaining the rationale for this placement

## Implementation Details
The change addresses a critical animation bug where:
- When modifiers lived inside the `HijackingScrollView` closure, they sat on the hosted content of a UIHostingController
- Animation context didn't propagate across the UIKit boundary, causing the tear-time fade to be a hard cut
- Interrupted animations could leave events stuck at mid-fade opacity (~0.5) until app restart

By moving these modifiers outside the scroll view, `withAnimation` transactions now resolve in the native SwiftUI tree where animation context properly propagates, eliminating the visual glitches and animation state corruption.

https://claude.ai/code/session_011aDHbLn8pBz5EaHDJdyirb