### PR TITLE
Add Clock observable for real-time "today" tracking

### DIFF
--- a/Hibi/ContentView.swift
+++ b/Hibi/ContentView.swift
@@ -25,6 +25,7 @@ struct ContentView: View {
     @State private var selectedDay = SampleData.todayDay
     @State private var eventStore = EventStore()
     @State private var weatherStore = WeatherStore()
+    @State private var clock = Clock()
     @State private var editorMode: EventEditorSheet.Mode?
     @State private var showOnboarding = false
     @State private var needsOnboarding = false
@@ -62,6 +63,30 @@ struct ContentView: View {
                 selection = newValue
             }
         )
+    }
+
+    /// Triggered by `NSCalendarDayChanged` and by scene-foreground transitions
+    /// (catches the case where the app was backgrounded across midnight). If
+    /// the user was looking at "today" before the rollover, advance their
+    /// displayed date so they stay on today; otherwise leave the selection
+    /// alone — the today highlight will refresh on its own because views read
+    /// from the `Clock` we just updated. The new month is also pre-loaded so
+    /// reminders that pivot on `Date()` (overdue carry-over) reflect the new day.
+    private func handleDayChange() {
+        let wasOnOldToday = displayedYear == clock.year
+            && displayedMonth == clock.month
+            && selectedDay == clock.day
+        guard clock.refresh() != nil else { return }
+        if wasOnOldToday {
+            displayedYear = clock.year
+            displayedMonth = clock.month
+            selectedDay = clock.day
+            // Bump the scroll token so list-based tabs recenter on the new
+            // today — without it, the Week list still shows the previous
+            // day at center after midnight even though selectedDay advanced.
+            scrollToNowToken &+= 1
+        }
+        eventStore.ensureLoaded(year: clock.year, month: clock.month)
     }
 
     private func returnToNow() {
@@ -152,6 +177,7 @@ struct ContentView: View {
         }
         .environment(eventStore)
         .environment(weatherStore)
+        .environment(clock)
         .whatsNewSheet(onDismiss: {
             if needsOnboarding {
                 showOnboarding = true
@@ -224,7 +250,11 @@ struct ContentView: View {
             if phase == .active {
                 eventStore.refreshAccessFromScenePhase()
                 weatherStore.refresh()
+                handleDayChange()
             }
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .NSCalendarDayChanged)) { _ in
+            handleDayChange()
         }
         .preferredColorScheme(colorScheme)
         .tint(.primary)

--- a/Hibi/Models/Clock.swift
+++ b/Hibi/Models/Clock.swift
@@ -1,0 +1,53 @@
+import Foundation
+import Observation
+
+/// Observable "what day is it right now" source. Views that highlight today
+/// read `clock.isToday(...)` so a redraw is triggered when the wall clock
+/// crosses midnight (or the user changes time zone / system date).
+/// `ContentView` owns the single instance, calls `refresh()` from
+/// `NSCalendarDayChanged` and scene-foreground transitions, and injects it
+/// via `.environment(_:)`.
+@MainActor
+@Observable
+final class Clock {
+    private(set) var year: Int
+    private(set) var month: Int
+    private(set) var day: Int
+
+    init() {
+        let c = Self.currentComponents()
+        self.year = c.year
+        self.month = c.month
+        self.day = c.day
+    }
+
+    /// Re-read the current date. Returns the previous (y, m, d) if the day
+    /// rolled over so the caller can decide whether to follow the user along
+    /// (e.g. advance a "viewing today" selection to the new today). Returns
+    /// nil when nothing changed.
+    @discardableResult
+    func refresh() -> (year: Int, month: Int, day: Int)? {
+        let c = Self.currentComponents()
+        guard c.year != year || c.month != month || c.day != day else { return nil }
+        let previous = (year: year, month: month, day: day)
+        year = c.year
+        month = c.month
+        day = c.day
+        return previous
+    }
+
+    func isToday(year: Int, month: Int, day: Int) -> Bool {
+        year == self.year && month == self.month && day == self.day
+    }
+
+    private static func currentComponents() -> (year: Int, month: Int, day: Int) {
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = .current
+        let c = cal.dateComponents([.year, .month, .day], from: Date())
+        return (
+            c.year ?? SampleData.demoAnchorYear,
+            c.month ?? SampleData.demoAnchorMonth,
+            c.day ?? SampleData.demoAnchorDay
+        )
+    }
+}

--- a/Hibi/Models/SampleData.swift
+++ b/Hibi/Models/SampleData.swift
@@ -57,11 +57,6 @@ enum SampleData {
         return cal.component(.weekday, from: date) - 1
     }
 
-    static func isToday(year: Int, month: Int, day: Int) -> Bool {
-        let t = todayComponents
-        return year == t.year && month == t.month && day == t.day
-    }
-
     /// True when the given (y, m, d) matches the fixed demo anchor date.
     /// Used only by the demo-time-of-day branch in `CalendarEvent.progress`.
     static func isDemoAnchor(year: Int, month: Int, day: Int) -> Bool {

--- a/Hibi/Views/DayView.swift
+++ b/Hibi/Views/DayView.swift
@@ -15,6 +15,7 @@ struct DayView: View {
 
     @Environment(EventStore.self) private var eventStore
     @Environment(WeatherStore.self) private var weatherStore
+    @Environment(Clock.self) private var clock
     @Environment(\.colorScheme) private var colorScheme
     @AppStorage("invertDaySwipe") private var invertDaySwipe: Bool = false
     @AppStorage("useSimpleFont") private var useSimpleFont: Bool = false
@@ -362,7 +363,7 @@ struct DayView: View {
     ) -> some View {
         let shape = RoundedRectangle(cornerRadius: 18)
         let weather = weatherStore.weather(year: dayInfo.year, month: dayInfo.month, day: dayInfo.day)
-        let isToday = SampleData.isToday(year: dayInfo.year, month: dayInfo.month, day: dayInfo.day)
+        let isToday = clock.isToday(year: dayInfo.year, month: dayInfo.month, day: dayInfo.day)
 
         // Hairline border for cards behind the front — defines the card
         // silhouette against the background (critical in dark mode where

--- a/Hibi/Views/MonthView.swift
+++ b/Hibi/Views/MonthView.swift
@@ -96,13 +96,14 @@ private struct DayCell: View {
     let day: Int
 
     @Environment(EventStore.self) private var eventStore
+    @Environment(Clock.self) private var clock
     @AppStorage("useSimpleFont") private var useSimpleFont: Bool = false
 
     var body: some View {
         let events = eventStore.events(year: year, month: month, day: day)
         let reminders = eventStore.reminders(year: year, month: month, day: day)
             .filter { !$0.isCompleted }
-        let isToday = SampleData.isToday(year: year, month: month, day: day)
+        let isToday = clock.isToday(year: year, month: month, day: day)
         let dots: [(id: String, tint: Color)] =
             reminders.prefix(2).map { (id: $0.id, tint: $0.tint) }
             + events.prefix(4 - min(reminders.count, 2)).map { (id: $0.id, tint: $0.tint) }

--- a/Hibi/Views/StreamView.swift
+++ b/Hibi/Views/StreamView.swift
@@ -254,6 +254,7 @@ private struct StreamDayRow: View {
 
     @Environment(EventStore.self) private var eventStore
     @Environment(WeatherStore.self) private var weatherStore
+    @Environment(Clock.self) private var clock
     @State private var isDropTargeted: Bool = false
     @AppStorage("useSimpleFont") private var useSimpleFont: Bool = false
     @AppStorage(TemperatureUnit.defaultsKey) private var temperatureUnitRaw: String = TemperatureUnit.system.rawValue
@@ -267,7 +268,7 @@ private struct StreamDayRow: View {
         let reminders = eventStore.reminders(year: year, month: month, day: day)
         let wx = weatherStore.weather(year: year, month: month, day: day)
         let weekday = SampleData.weekday(year: year, month: month, day: day)
-        let isToday = SampleData.isToday(year: year, month: month, day: day)
+        let isToday = clock.isToday(year: year, month: month, day: day)
         // Row divider appears at the start of each week so the stream reads as
         // week-sized groups. Uses locale's first weekday (German=Mon, Sun else).
         let firstDayOfWeek = Calendar.autoupdatingCurrent.firstWeekday - 1


### PR DESCRIPTION
## Summary
Introduces a new `Clock` observable model to track the current date and automatically refresh views when the calendar day changes. This replaces the static `SampleData.isToday()` function with a dynamic, environment-injected clock that triggers redraws on midnight transitions and scene foreground events.

## Key Changes
- **New `Clock` model** (`Hibi/Models/Clock.swift`): Observable class that maintains current year/month/day and provides `isToday()` checks. The `refresh()` method detects day rollovers and returns the previous date to enable smart UI updates.
- **ContentView integration**: 
  - Creates and owns a single `Clock` instance
  - Implements `handleDayChange()` to respond to midnight transitions and app foreground events
  - Advances the user's displayed date if they were viewing "today" when the day rolled over
  - Pre-loads the new month's data for reminders that depend on `Date()`
  - Injects clock via environment for all child views
- **View updates**: `DayView`, `MonthView`, and `StreamView` now read from the injected `Clock` environment instead of calling the static `SampleData.isToday()` function
- **Cleanup**: Removed the now-unused `SampleData.isToday()` function

## Implementation Details
- `Clock` uses `@Observable` and `@MainActor` for thread-safe reactive updates
- Responds to both `NSCalendarDayChanged` notifications and scene phase transitions to catch midnight rollovers even when the app is backgrounded
- Increments `scrollToNowToken` on day change to recenter list-based tabs on the new today
- Falls back to demo anchor date components if system date components are unavailable

https://claude.ai/code/session_01Qj7hydUxAb3vfBM5yq2s64