### PR TITLE
Remove masthead from DayView

### DIFF
--- a/Hibi/Views/DayView.swift
+++ b/Hibi/Views/DayView.swift
@@ -104,6 +104,7 @@ struct DayView: View {
         VStack(spacing: 0) {
             tearStack
                 .padding(.horizontal, 16)
+                .padding(.top, 20)
                 .padding(.bottom, 4)
                 .sensoryFeedback(.impact(weight: .medium), trigger: tearCommitCount)
             pullToTearHint

--- a/Hibi/Views/DayView.swift
+++ b/Hibi/Views/DayView.swift
@@ -102,7 +102,6 @@ struct DayView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            masthead
             tearStack
                 .padding(.horizontal, 16)
                 .padding(.bottom, 4)
@@ -228,27 +227,6 @@ struct DayView: View {
             .opacity(tearHintOpacity * chromeFadeOpacity)
             .clipped()
             .animation(.easeOut(duration: 0.32), value: isTearing)
-    }
-
-    // MARK: - Masthead
-
-    private var masthead: some View {
-        HStack {
-            // Typographic constant — identical across all locales per design.
-            Text(verbatim: "日々 · No. \(String(format: "%03d", day))")
-                .font(.system(size: 11, weight: .medium))
-                .tracking(1.8)
-                .foregroundStyle(.secondary)
-                .contentTransition(.numericText(value: Double(day)))
-            Spacer()
-            // Typographic constant — identical across all locales per design.
-            Text(verbatim: "est. MMXXVI")
-                .font(.appSerif(size: 13, italic: true, simple: useSimpleFont))
-                .foregroundStyle(.secondary)
-        }
-        .padding(.horizontal, 20)
-        .padding(.top, 2)
-        .padding(.bottom, 14)
     }
 
     // MARK: - Tear stack (3-card paper stack)


### PR DESCRIPTION
Removes the masthead UI component from the top of DayView, which displayed the day number and establishment year.

## Changes
- Removed the `masthead` view from the VStack in DayView's body
- Deleted the entire `masthead` computed property (23 lines), including:
  - Day number display with numeric text transition
  - Establishment year text
  - Associated padding and styling

## Details
The masthead was a header section that showed "日々 · No. XXX" and "est. MMXXVI" with secondary styling. This change simplifies the DayView layout by removing this decorative header element.

https://claude.ai/code/session_01FfZ7KiggkmKstM6gsg1Zbf