### PR TITLE
Refactor weather attribution text to use string interpolation

### DIFF
--- a/Hibi/Views/DayView.swift
+++ b/Hibi/Views/DayView.swift
@@ -913,7 +913,7 @@ private struct PageContent: View {
 private struct AppleWeatherAttribution: View {
     var body: some View {
         Link(destination: URL(string: "https://weatherkit.apple.com/legal-attribution.html")!) {
-            (Text(Image(systemName: "apple.logo")) + Text(verbatim: "\u{00a0}Weather"))
+            Text("\(Image(systemName: "apple.logo"))\u{00a0}Weather")
                 .font(.system(size: 10, weight: .regular))
                 .foregroundStyle(.secondary)
         }

--- a/Hibi/Views/SettingsView.swift
+++ b/Hibi/Views/SettingsView.swift
@@ -130,7 +130,7 @@ struct SettingsView: View {
                     }
 
                     Link(destination: URL(string: "https://weatherkit.apple.com/legal-attribution.html")!) {
-                        (Text("Weather data provided by ") + Text(Image(systemName: "apple.logo")) + Text(verbatim: "\u{00a0}Weather"))
+                        Text("Weather data provided by \(Image(systemName: "apple.logo"))\u{00a0}Weather")
                             .foregroundStyle(.secondary)
                             .font(.footnote)
                     }


### PR DESCRIPTION
## Summary
Simplified the weather attribution text rendering in two locations by replacing `Text` concatenation with string interpolation syntax.

## Changes
- **DayView.swift**: Updated `AppleWeatherAttribution` to use string interpolation instead of concatenating multiple `Text` views
- **SettingsView.swift**: Updated weather data attribution link text to use string interpolation instead of concatenating three separate `Text` views

## Implementation Details
Both changes convert from the pattern:
```swift
(Text(...) + Text(Image(...)) + Text(...))
```

To the more concise pattern:
```swift
Text("...\(Image(...))\u{00a0}...")
```

This maintains the same visual output while improving code readability and reducing the number of view components being composed.

https://claude.ai/code/session_01Mn7Y11CNxwYnmZCEhQpNuz