### PR TITLE
fix Events widget dark-mode contrast

### DIFF
--- a/HibiWidgets/EventsWidget.swift
+++ b/HibiWidgets/EventsWidget.swift
@@ -11,10 +11,13 @@ struct EventsWidget: Widget {
             provider: EventsTimelineProvider()
         ) { entry in
             EventsWidgetView(entry: entry)
-                // Matches the in-app canvas behind events (cream radial in
-                // light, near-black radial in dark) — not the paper card,
-                // which reads as a warm yellow against the widget's host.
-                .containerBackground(for: .widget) { AppBackgroundGradient() }
+                // Paper canvas — matches the Today's Page widget so the two
+                // widgets read as a set. In dark mode, the radial app
+                // gradient only sampled its outer (near-black) ring at
+                // widget dimensions, which crushed the pill tints; the flat
+                // card1 surface (cream / #242424) gives the pastel tints
+                // enough contrast to read.
+                .containerBackground(PaperTints.card1, for: .widget)
                 // TODO: per-event deep links (open the tapped event in-app).
                 // For now any tap opens the Day tab.
                 .widgetURL(URL(string: "hibi://today"))


### PR DESCRIPTION
The widget used `AppBackgroundGradient` as its container background, but
at widget dimensions (~158pt frame vs the app's ~900pt screen) only the
outer near-black ring of the radial gradient is visible. The 10%-opacity
pill tints then sat on near-pure-black, leaving time labels and
secondary text effectively unreadable.

Switch to `PaperTints.card1` — the same flat paper surface the Today's
Page widget already uses (cream in light, #242424 in dark). Light mode
is visually identical; dark mode gets enough contrast for the pastel
tints and darkened time text to read.