### PR TITLE
Replace WhatsNewKit with Notelet for changelog management

### DIFF
--- a/.agents/skills/create-release/SKILL.md
+++ b/.agents/skills/create-release/SKILL.md
@@ -23,17 +23,19 @@ Use `replace_all` since both configurations must match.
 
 ### 3. Update WhatsNewContent.swift
 
+Hibi's changelog uses [Notelet](https://github.com/mykolaharmash/notelet). Each release is one `NoteletVersionNotes` built via the private `notes(_:_:)` helper, holding a single `.list` item whose `rows` are the features (one `NoteletVersionNoteItem.ListRow` per change, with `symbolSystemName`, `title`, `description`).
+
 In `Hibi/Models/WhatsNewContent.swift`:
 
-1. Copy the current `latest` body into a new `static var v1_X` (using the OLD version number, e.g. `v1_8`), changing only `version:` to a hardcoded string (e.g. `"1.8"`).
-2. Replace `latest`'s features with the new release features (one `WhatsNew.Feature` per change, with SF Symbol, localized title, localized subtitle).
+1. Copy the current `latest` body into a new `static var v1_X` (using the OLD version number, e.g. `v1_8`), changing the `notes(version, …)` call to a hardcoded string (e.g. `notes("1.8", …)`).
+2. Replace `latest`'s rows with the new release features (one `.init(symbolSystemName:title:description:)` per change). `title`/`description` are `LocalizedStringResource` string literals — the literal IS the localization key.
 3. Update `static let version` to the new version string.
 4. Update the doc comment `MARKETING_VERSION` reference.
-5. Add the new `v1_X` to `collection` after `latest`.
+5. Add the new `v1_X` to `allNotes` after `latest`.
 
 ### 4. Add localizations
 
-Add each new `String(localized:)` key to `Hibi/Localizable.xcstrings` with translations for **all 11 locales**: `de`, `en`, `es`, `it`, `ja`, `ko`, `ms`, `pt-BR`, `zh-Hans-CN`, `zh-Hant-HK`, `zh-Hant-TW`.
+Add each new `title`/`description` string literal as a key in `Hibi/Localizable.xcstrings` with translations for **all 11 locales**: `de`, `en`, `es`, `it`, `ja`, `ko`, `ms`, `pt-BR`, `zh-Hans-CN`, `zh-Hant-HK`, `zh-Hant-TW`.
 
 Use Python/JSON to insert entries (the file is large). Set `extractionState: "manual"` and include a `comment` referencing the version.
 

--- a/Hibi.xcodeproj/project.pbxproj
+++ b/Hibi.xcodeproj/project.pbxproj
@@ -7,7 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		4B0450C42F94C6EF009EA06E /* WhatsNewKit in Frameworks */ = {isa = PBXBuildFile; productRef = 4B0450C32F94C6EF009EA06E /* WhatsNewKit */; };
+		4B0450C42F94C6EF009EA06E /* Notelet in Frameworks */ = {isa = PBXBuildFile; productRef = 4B0450C32F94C6EF009EA06E /* Notelet */; };
 		4B0451032F94C6EF009EA06E /* CalendarPermission in Frameworks */ = {isa = PBXBuildFile; productRef = 4B0451012F94C6EF009EA06E /* CalendarPermission */; };
 		4B0451042F94C6EF009EA06E /* LocationPermission in Frameworks */ = {isa = PBXBuildFile; productRef = 4B0451022F94C6EF009EA06E /* LocationPermission */; };
 		4B1507042FBEA5BF00F49AFD /* WidgetKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4B1507032FBEA5BF00F49AFD /* WidgetKit.framework */; };
@@ -120,7 +120,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				4B0450C42F94C6EF009EA06E /* WhatsNewKit in Frameworks */,
+				4B0450C42F94C6EF009EA06E /* Notelet in Frameworks */,
 				4B0451032F94C6EF009EA06E /* CalendarPermission in Frameworks */,
 				4B0451042F94C6EF009EA06E /* LocationPermission in Frameworks */,
 			);
@@ -202,7 +202,7 @@
 			);
 			name = Hibi;
 			packageProductDependencies = (
-				4B0450C32F94C6EF009EA06E /* WhatsNewKit */,
+				4B0450C32F94C6EF009EA06E /* Notelet */,
 				4B0451012F94C6EF009EA06E /* CalendarPermission */,
 				4B0451022F94C6EF009EA06E /* LocationPermission */,
 			);
@@ -248,7 +248,7 @@
 			mainGroup = 4B802FC42F8F5453008F00F4;
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
-				4B0450C22F94C6EF009EA06E /* XCRemoteSwiftPackageReference "WhatsNewKit" */,
+				4B0450C22F94C6EF009EA06E /* XCRemoteSwiftPackageReference "Notelet" */,
 				4B0451002F94C6EF009EA06E /* XCRemoteSwiftPackageReference "PermissionsKit" */,
 			);
 			preferredProjectObjectVersion = 77;
@@ -589,12 +589,12 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		4B0450C22F94C6EF009EA06E /* XCRemoteSwiftPackageReference "WhatsNewKit" */ = {
+		4B0450C22F94C6EF009EA06E /* XCRemoteSwiftPackageReference "Notelet" */ = {
 			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/SvenTiigi/WhatsNewKit";
+			repositoryURL = "https://github.com/mykolaharmash/notelet";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 2.2.1;
+				minimumVersion = 1.1.0;
 			};
 		};
 		4B0451002F94C6EF009EA06E /* XCRemoteSwiftPackageReference "PermissionsKit" */ = {
@@ -608,10 +608,10 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		4B0450C32F94C6EF009EA06E /* WhatsNewKit */ = {
+		4B0450C32F94C6EF009EA06E /* Notelet */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 4B0450C22F94C6EF009EA06E /* XCRemoteSwiftPackageReference "WhatsNewKit" */;
-			productName = WhatsNewKit;
+			package = 4B0450C22F94C6EF009EA06E /* XCRemoteSwiftPackageReference "Notelet" */;
+			productName = Notelet;
 		};
 		4B0451012F94C6EF009EA06E /* CalendarPermission */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Hibi.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Hibi.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -2,21 +2,21 @@
   "originHash" : "ed22328b129bd017fa539332038d160d3ad840f3c250e30a08e90e5d89459ba0",
   "pins" : [
     {
+      "identity" : "notelet",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mykolaharmash/notelet",
+      "state" : {
+        "revision" : "f01e68239a3e711895462e202b7cf1eac6f6bec3",
+        "version" : "1.1.0"
+      }
+    },
+    {
       "identity" : "permissionskit",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/sparrowcode/PermissionsKit",
       "state" : {
         "revision" : "5e5935998cf9c44033e429c3b7d1dd176a1f55ad",
         "version" : "11.1.0"
-      }
-    },
-    {
-      "identity" : "whatsnewkit",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/SvenTiigi/WhatsNewKit",
-      "state" : {
-        "revision" : "6157c77e8be9b3d2310bc680681b61a8d9e290ac",
-        "version" : "2.2.1"
       }
     }
   ],

--- a/Hibi/ContentView.swift
+++ b/Hibi/ContentView.swift
@@ -1,5 +1,5 @@
+import Notelet
 import SwiftUI
-import WhatsNewKit
 
 enum CalendarTab: Hashable {
     case month, stream, day
@@ -194,11 +194,16 @@ struct ContentView: View {
                 break
             }
         }
-        .whatsNewSheet(onDismiss: {
-            if needsOnboarding {
-                showOnboarding = true
-            }
-        })
+        .noteletSheet(
+            notes: WhatsNewContent.allNotes,
+            version: .current,
+            onDismiss: {
+                if needsOnboarding {
+                    showOnboarding = true
+                }
+            },
+            configuration: WhatsNewContent.configuration
+        )
         .sheet(isPresented: $showSettings, onDismiss: {
             if reopenOnboardingAfterSettings {
                 reopenOnboardingAfterSettings = false
@@ -238,8 +243,8 @@ struct ContentView: View {
                 let shouldOnboard = !eventStore.hasCalendarAccess
                     || (!eventStore.hasReminderAccess && !eventStore.reminderAccessDenied)
                 if shouldOnboard {
-                    let whatsNewWillPresent = !UserDefaultsWhatsNewVersionStore()
-                        .hasPresented(WhatsNewContent.version)
+                    let whatsNewWillPresent = NoteletStorage.getLatestSeenAppVersion()
+                        != WhatsNewContent.version
                     needsOnboarding = true
                     if !whatsNewWillPresent {
                         showOnboarding = true

--- a/Hibi/HibiApp.swift
+++ b/Hibi/HibiApp.swift
@@ -1,38 +1,29 @@
+import Notelet
 import SwiftUI
-import WhatsNewKit
 
 @main
 struct HibiApp: App {
-    private let whatsNewEnvironment: WhatsNewEnvironment
-
     init() {
         AppFont.registerFonts()
         AppGroup.migratePrefsIfNeeded()
-        self.whatsNewEnvironment = Self.makeWhatsNewEnvironment()
+        Self.markWhatsNewSeenOnFreshInstall()
     }
 
     var body: some Scene {
         WindowGroup {
             ContentView()
-                .environment(\.whatsNew, whatsNewEnvironment)
         }
     }
 
     /// Fresh installs should not see the What's New sheet — it's meant for
     /// updates. On the very first launch we mark the current version as
-    /// already presented, so WhatsNewKit only fires on subsequent upgrades.
-    private static func makeWhatsNewEnvironment() -> WhatsNewEnvironment {
-        let versionStore = UserDefaultsWhatsNewVersionStore()
+    /// already seen, so Notelet only fires on subsequent upgrades.
+    private static func markWhatsNewSeenOnFreshInstall() {
         let defaults = UserDefaults.standard
         let firstLaunchKey = "hasLaunchedBefore"
         if !defaults.bool(forKey: firstLaunchKey) {
-            versionStore.save(presentedVersion: WhatsNewContent.version)
+            NoteletStorage.markCurrentVersionAsSeen()
             defaults.set(true, forKey: firstLaunchKey)
         }
-        return WhatsNewEnvironment(
-            versionStore: versionStore,
-            whatsNewCollection: WhatsNewContent.collection
-        )
     }
-
 }

--- a/Hibi/Models/WhatsNewContent.swift
+++ b/Hibi/Models/WhatsNewContent.swift
@@ -1,216 +1,156 @@
+import Notelet
 import SwiftUI
-import WhatsNewKit
 
 /// Changelog shown on first launch after update, and re-openable from Settings.
 ///
-/// Version string must match `CFBundleShortVersionString` so
-/// `UserDefaultsWhatsNewVersionStore` correctly records the presentation.
-/// We currently ship `MARKETING_VERSION = 1.10`.
+/// `version` must match `CFBundleShortVersionString` so Notelet's `.current`
+/// presentation records the changelog as seen. We currently ship
+/// `MARKETING_VERSION = 1.10`.
 enum WhatsNewContent {
-    static let version: WhatsNew.Version = "1.10"
+    static let version = "1.10"
 
-    /// Built on access so `String(localized:)` resolves against the user's current locale.
-    static var latest: WhatsNew {
-        WhatsNew(
-            version: version,
-            title: .init(stringLiteral: String(localized: "What's New in Hibi")),
-            features: [
-                WhatsNew.Feature(
-                    image: .init(systemName: "rectangle.expand.vertical"),
-                    title: .init(String(localized: "Expandable schedule")),
-                    subtitle: .init(String(localized: "Pull the Schedule handle down to collapse the day's paper stack and see more of your events at once."))
-                ),
-                WhatsNew.Feature(
-                    image: .init(systemName: "calendar.badge.clock"),
-                    title: .init(String(localized: "Updates at midnight")),
-                    subtitle: .init(String(localized: "If you leave the app open overnight, the highlighted day now advances to the new day at midnight."))
-                ),
-            ],
-            primaryAction: WhatsNew.PrimaryAction(
-                title: .init(String(localized: "Continue")),
-                backgroundColor: .primary,
-                foregroundColor: Color(uiColor: .systemBackground),
-                hapticFeedback: .selection
-            )
+    /// Single page, dark "Continue" button to match the app's monochrome chrome.
+    static var configuration: NoteletConfiguration {
+        NoteletConfiguration(
+            doneButtonLabel: "Continue",
+            accentColor: .primary
         )
     }
 
-    static var v1_9: WhatsNew {
-        WhatsNew(
-            version: "1.9",
-            title: .init(stringLiteral: String(localized: "What's New in Hibi")),
-            features: [
-                WhatsNew.Feature(
-                    image: .init(systemName: "arrow.left.arrow.right"),
-                    title: .init(String(localized: "Seamless tab switching")),
-                    subtitle: .init(String(localized: "Switching between Month, Week, and Day now picks up right where you left off."))
-                ),
-                WhatsNew.Feature(
-                    image: .init(systemName: "mappin"),
-                    title: .init(String(localized: "Scrolling location names")),
-                    subtitle: .init(String(localized: "Long venue names now scroll smoothly instead of being cut off."))
-                ),
-                WhatsNew.Feature(
-                    image: .init(systemName: "repeat"),
-                    title: .init(String(localized: "Recurring event fixes")),
-                    subtitle: .init(String(localized: "Deleting a single occurrence of a recurring event now removes just that one, not the entire series."))
-                ),
-                WhatsNew.Feature(
-                    image: .init(systemName: "arrow.clockwise"),
-                    title: .init(String(localized: "Event sync fix")),
-                    subtitle: .init(String(localized: "Events you create now appear on the calendar right away — no more waiting for an app restart to see them."))
-                ),
-            ],
-            primaryAction: WhatsNew.PrimaryAction(
-                title: .init(String(localized: "Continue")),
-                backgroundColor: .primary,
-                foregroundColor: Color(uiColor: .systemBackground),
-                hapticFeedback: .selection
-            )
-        )
+    static var allNotes: [NoteletVersionNotes] {
+        [latest, v1_9, v1_8, v1_7, v1_5, v1_4, v1_3, v1_2]
     }
 
-    static var v1_8: WhatsNew {
-        WhatsNew(
-            version: "1.8",
-            title: .init(stringLiteral: String(localized: "What's New in Hibi")),
-            features: [
-                WhatsNew.Feature(
-                    image: .init(systemName: "checklist"),
-                    title: .init(String(localized: "Reminders")),
-                    subtitle: .init(String(localized: "Your reminders now appear alongside calendar events. Tap the checkbox to mark them complete — right from Hibi."))
-                ),
-                WhatsNew.Feature(
-                    image: .init(systemName: "arrow.triangle.2.circlepath"),
-                    title: .init(String(localized: "Recurring events")),
-                    subtitle: .init(String(localized: "Recurring calendar events now show a small repeat icon, so you can tell them apart at a glance."))
-                ),
-                WhatsNew.Feature(
-                    image: .init(systemName: "calendar"),
-                    title: .init(String(localized: "Polished month grid")),
-                    subtitle: .init(String(localized: "The today indicator no longer clips into the row below — the month grid has proper breathing room now."))
-                ),
-            ],
-            primaryAction: WhatsNew.PrimaryAction(
-                title: .init(String(localized: "Continue")),
-                backgroundColor: .primary,
-                foregroundColor: Color(uiColor: .systemBackground),
-                hapticFeedback: .selection
-            )
-        )
+    /// Shared header. `LocalizedStringResource` resolves lazily against the
+    /// user's current locale, so each entry stays localized without rebuilding.
+    private static let title: LocalizedStringResource = "What's New in Hibi"
+
+    private static func notes(
+        _ version: String,
+        _ rows: [NoteletVersionNoteItem.ListRow]
+    ) -> NoteletVersionNotes {
+        NoteletVersionNotes(version: version, items: [.list(title: title, rows: rows)])
     }
 
-    static var v1_7: WhatsNew {
-        WhatsNew(
-            version: "1.7",
-            title: .init(stringLiteral: String(localized: "What's New in Hibi")),
-            features: [
-                WhatsNew.Feature(
-                    image: .init(systemName: "character.bubble"),
-                    title: .init(String(localized: "More languages")),
-                    subtitle: .init(String(localized: "Hibi now includes Traditional Chinese for Taiwan and Hong Kong, Simplified Chinese for Mainland China, plus Korean, Malay, Spanish, Brazilian Portuguese, and Italian."))
-                ),
-            ],
-            primaryAction: WhatsNew.PrimaryAction(
-                title: .init(String(localized: "Continue")),
-                backgroundColor: .primary,
-                foregroundColor: Color(uiColor: .systemBackground),
-                hapticFeedback: .selection
-            )
-        )
+    static var latest: NoteletVersionNotes {
+        notes(version, [
+            .init(
+                symbolSystemName: "rectangle.expand.vertical",
+                title: "Expandable schedule",
+                description: "Pull the Schedule handle down to collapse the day's paper stack and see more of your events at once."
+            ),
+            .init(
+                symbolSystemName: "calendar.badge.clock",
+                title: "Updates at midnight",
+                description: "If you leave the app open overnight, the highlighted day now advances to the new day at midnight."
+            ),
+        ])
+    }
+
+    static var v1_9: NoteletVersionNotes {
+        notes("1.9", [
+            .init(
+                symbolSystemName: "arrow.left.arrow.right",
+                title: "Seamless tab switching",
+                description: "Switching between Month, Week, and Day now picks up right where you left off."
+            ),
+            .init(
+                symbolSystemName: "mappin",
+                title: "Scrolling location names",
+                description: "Long venue names now scroll smoothly instead of being cut off."
+            ),
+            .init(
+                symbolSystemName: "repeat",
+                title: "Recurring event fixes",
+                description: "Deleting a single occurrence of a recurring event now removes just that one, not the entire series."
+            ),
+            .init(
+                symbolSystemName: "arrow.clockwise",
+                title: "Event sync fix",
+                description: "Events you create now appear on the calendar right away — no more waiting for an app restart to see them."
+            ),
+        ])
+    }
+
+    static var v1_8: NoteletVersionNotes {
+        notes("1.8", [
+            .init(
+                symbolSystemName: "checklist",
+                title: "Reminders",
+                description: "Your reminders now appear alongside calendar events. Tap the checkbox to mark them complete — right from Hibi."
+            ),
+            .init(
+                symbolSystemName: "arrow.triangle.2.circlepath",
+                title: "Recurring events",
+                description: "Recurring calendar events now show a small repeat icon, so you can tell them apart at a glance."
+            ),
+            .init(
+                symbolSystemName: "calendar",
+                title: "Polished month grid",
+                description: "The today indicator no longer clips into the row below — the month grid has proper breathing room now."
+            ),
+        ])
+    }
+
+    static var v1_7: NoteletVersionNotes {
+        notes("1.7", [
+            .init(
+                symbolSystemName: "character.bubble",
+                title: "More languages",
+                description: "Hibi now includes Traditional Chinese for Taiwan and Hong Kong, Simplified Chinese for Mainland China, plus Korean, Malay, Spanish, Brazilian Portuguese, and Italian."
+            ),
+        ])
     }
 
     // MARK: - Previous versions
 
-    static var v1_5: WhatsNew {
-        WhatsNew(
-            version: "1.5",
-            title: .init(stringLiteral: String(localized: "What's New in Hibi")),
-            features: [
-                WhatsNew.Feature(
-                    image: .init(systemName: "sparkles"),
-                    title: .init(String(localized: "Discover more apps")),
-                    subtitle: .init(String(localized: "Settings now links to apps.weichart.de, where you can find my other apps ^^"))
-                ),
-            ],
-            primaryAction: WhatsNew.PrimaryAction(
-                title: .init(String(localized: "Continue")),
-                backgroundColor: .primary,
-                foregroundColor: Color(uiColor: .systemBackground),
-                hapticFeedback: .selection
-            )
-        )
+    static var v1_5: NoteletVersionNotes {
+        notes("1.5", [
+            .init(
+                symbolSystemName: "sparkles",
+                title: "Discover more apps",
+                description: "Settings now links to apps.weichart.de, where you can find my other apps ^^"
+            ),
+        ])
     }
 
-    static var v1_4: WhatsNew {
-        WhatsNew(
-            version: "1.4",
-            title: .init(stringLiteral: String(localized: "What's New in Hibi")),
-            features: [
-                WhatsNew.Feature(
-                    image: .init(systemName: "calendar.badge.arrow.right"),
-                    title: .init(String(localized: "Seamless month transitions")),
-                    subtitle: .init(String(localized: "Tearing past the last or first day of a month now smoothly continues into the next or previous month."))
-                ),
-            ],
-            primaryAction: WhatsNew.PrimaryAction(
-                title: .init(String(localized: "Continue")),
-                backgroundColor: .primary,
-                foregroundColor: Color(uiColor: .systemBackground),
-                hapticFeedback: .selection
-            )
-        )
+    static var v1_4: NoteletVersionNotes {
+        notes("1.4", [
+            .init(
+                symbolSystemName: "calendar.badge.arrow.right",
+                title: "Seamless month transitions",
+                description: "Tearing past the last or first day of a month now smoothly continues into the next or previous month."
+            ),
+        ])
     }
 
-    static var v1_3: WhatsNew {
-        WhatsNew(
-            version: "1.3",
-            title: .init(stringLiteral: String(localized: "What's New in Hibi")),
-            features: [
-                WhatsNew.Feature(
-                    image: .init(systemName: "thermometer.medium"),
-                    title: .init(String(localized: "Temperature & time format")),
-                    subtitle: .init(String(localized: "Choose Celsius or Fahrenheit, and 12-hour or 24-hour time — or let the system decide."))
-                ),
-                WhatsNew.Feature(
-                    image: .init(systemName: "arrow.down.doc"),
-                    title: .init(String(localized: "New back animation")),
-                    subtitle: .init(String(localized: "Navigating to the previous day now slides a new page onto the stack instead of tearing one away."))
-                ),
-            ],
-            primaryAction: WhatsNew.PrimaryAction(
-                title: .init(String(localized: "Continue")),
-                backgroundColor: .primary,
-                foregroundColor: Color(uiColor: .systemBackground),
-                hapticFeedback: .selection
-            )
-        )
+    static var v1_3: NoteletVersionNotes {
+        notes("1.3", [
+            .init(
+                symbolSystemName: "thermometer.medium",
+                title: "Temperature & time format",
+                description: "Choose Celsius or Fahrenheit, and 12-hour or 24-hour time — or let the system decide."
+            ),
+            .init(
+                symbolSystemName: "arrow.down.doc",
+                title: "New back animation",
+                description: "Navigating to the previous day now slides a new page onto the stack instead of tearing one away."
+            ),
+        ])
     }
 
-    static var v1_2: WhatsNew {
-        WhatsNew(
-            version: "1.2",
-            title: .init(stringLiteral: String(localized: "What's New in Hibi")),
-            features: [
-                WhatsNew.Feature(
-                    image: .init(systemName: "checkmark.shield"),
-                    title: .init(String(localized: "Permissions, walked through")),
-                    subtitle: .init(String(localized: "A first-launch sheet grants Calendar and Location access in one place, and dismisses itself once you're set."))
-                ),
-                WhatsNew.Feature(
-                    image: .init(systemName: "calendar"),
-                    title: .init(String(localized: "Month opens on today")),
-                    subtitle: .init(String(localized: "Fixed a case where Month could land on the wrong month if you'd scrolled Week first."))
-                ),
-            ],
-            primaryAction: WhatsNew.PrimaryAction(
-                title: .init(String(localized: "Continue")),
-                backgroundColor: .primary,
-                foregroundColor: Color(uiColor: .systemBackground),
-                hapticFeedback: .selection
-            )
-        )
+    static var v1_2: NoteletVersionNotes {
+        notes("1.2", [
+            .init(
+                symbolSystemName: "checkmark.shield",
+                title: "Permissions, walked through",
+                description: "A first-launch sheet grants Calendar and Location access in one place, and dismisses itself once you're set."
+            ),
+            .init(
+                symbolSystemName: "calendar",
+                title: "Month opens on today",
+                description: "Fixed a case where Month could land on the wrong month if you'd scrolled Week first."
+            ),
+        ])
     }
-
-    static var collection: WhatsNewCollection { [latest, v1_9, v1_8, v1_7, v1_5, v1_4, v1_3, v1_2] }
 }

--- a/Hibi/Views/SettingsView.swift
+++ b/Hibi/Views/SettingsView.swift
@@ -1,6 +1,6 @@
 import EventKit
+import Notelet
 import SwiftUI
-import WhatsNewKit
 
 struct SettingsView: View {
     /// Called by the "Review permissions" button. ContentView latches this and
@@ -16,7 +16,7 @@ struct SettingsView: View {
     @AppStorage("useSimpleFont", store: AppGroup.defaults) private var useSimpleFont: Bool = false
     @AppStorage(TemperatureUnit.defaultsKey, store: AppGroup.defaults) private var temperatureUnitRaw: String = TemperatureUnit.system.rawValue
     @AppStorage(TimeFormat.defaultsKey, store: AppGroup.defaults) private var timeFormatRaw: String = TimeFormat.system.rawValue
-    @State private var showWhatsNew = false
+    @State private var whatsNewVersion: NoteletPresentedVersion?
 
     enum Appearance: String, CaseIterable, Identifiable {
         case system, light, dark
@@ -137,7 +137,7 @@ struct SettingsView: View {
                 }
 
                 Section("Release") {
-                    Button("What's New") { showWhatsNew = true }
+                    Button("What's New") { whatsNewVersion = .v(WhatsNewContent.version) }
                         .tint(.primary)
                     LabeledContent("Version", value: Self.versionLabel)
                 }
@@ -149,9 +149,12 @@ struct SettingsView: View {
                     Button("Done") { dismiss() }
                 }
             }
-            .sheet(isPresented: $showWhatsNew) {
-                WhatsNewView(whatsNew: WhatsNewContent.latest)
-            }
+            .noteletSheet(
+                notes: WhatsNewContent.allNotes,
+                version: whatsNewVersion,
+                onDismiss: { whatsNewVersion = nil },
+                configuration: WhatsNewContent.configuration
+            )
         }
     }
 


### PR DESCRIPTION
Migrate the "What's New" changelog system from WhatsNewKit to Notelet, a lighter-weight alternative that better fits Hibi's design language.

## Summary
This PR replaces the WhatsNewKit dependency with Notelet across the codebase. Notelet provides a simpler, more flexible API for presenting versioned changelogs while maintaining the same user-facing behavior.

## Key Changes

- **WhatsNewContent.swift**: Refactored all changelog entries from `WhatsNew` objects to `NoteletVersionNotes` using a new private `notes(_:_:)` helper. Each version now uses a single `.list` item with `NoteletVersionNoteItem.ListRow` entries instead of individual `WhatsNew.Feature` objects. Added `configuration` property for Notelet's presentation settings (dark "Continue" button, primary accent color).

- **ContentView.swift**: Replaced `.whatsNewSheet(onDismiss:)` modifier with `.noteletSheet(notes:version:onDismiss:configuration:)`, passing `WhatsNewContent.allNotes` and using `.current` for automatic version tracking. Updated version comparison logic to use `NoteletStorage.getLatestSeenAppVersion()` instead of `UserDefaultsWhatsNewVersionStore()`.

- **HibiApp.swift**: Simplified initialization by removing `WhatsNewEnvironment` setup. Replaced `UserDefaultsWhatsNewVersionStore().save(presentedVersion:)` with `NoteletStorage.markCurrentVersionAsSeen()` for fresh install handling.

- **SettingsView.swift**: Changed "What's New" button to use `NoteletPresentedVersion` state instead of a boolean flag, allowing direct version selection via `.v(WhatsNewContent.version)`.

- **Project configuration**: Updated package dependency from WhatsNewKit to Notelet in `project.pbxproj` and `Package.resolved`.

## Implementation Details

- The shared changelog title (`"What's New in Hibi"`) now uses `LocalizedStringResource` for lazy locale resolution, ensuring each version entry stays properly localized without rebuilding.
- Version string matching with `CFBundleShortVersionString` is preserved through Notelet's `.current` presentation mode.
- The monochrome UI aesthetic is maintained via `NoteletConfiguration` with primary accent color and custom button label.

https://claude.ai/code/session_01N9STA5NggvC2mNyEmig81T