### PR TITLE
Add gyro-based parallax effect to paper stack in Day view

### DIFF
--- a/Hibi/Models/MotionStore.swift
+++ b/Hibi/Models/MotionStore.swift
@@ -3,11 +3,17 @@ import Observation
 
 /// Observable device-tilt source for the Day view's paper-stack parallax.
 ///
-/// Reports tilt **relative to the orientation the device was in when `start()`
-/// was called** — a reference pose is captured on the first sample and every
-/// later sample is expressed as a delta from it. That makes "however you're
-/// holding the phone right now" the neutral pose, so the stack rests centered
-/// whether you're upright on a couch or flat on a desk.
+/// **Motion-based, not orientation-based.** The effect responds to *changes* in
+/// tilt, then eases back to neutral: move the phone and the stack drifts; hold
+/// it steady at any angle and it returns to base. That's deliberate — people
+/// don't hold a phone perfectly upright, and an absolute-tilt mapping would
+/// leave a permanent offset for whatever resting angle they happen to use.
+///
+/// The recentering is a high-pass filter: a baseline pose continuously drifts
+/// toward the current pose (`baselineFollow`), and the output is the difference
+/// between the two. A sustained pose is absorbed by the baseline and decays to
+/// zero; a quick move outruns the baseline and produces a transient that springs
+/// back once you settle.
 ///
 /// Tilt is derived from the **gravity vector**, not the attitude's Euler
 /// angles. Euler `pitch`/`roll` degenerate (gimbal lock) when the phone is held
@@ -22,18 +28,23 @@ import Observation
 @MainActor
 @Observable
 final class MotionStore {
-    /// Smoothed left/right lean from rest, roughly -1…1.
+    /// Smoothed left/right lean transient, roughly -1…1. Decays to 0 at rest.
     private(set) var tiltX: Double = 0
-    /// Smoothed front/back recline from rest, roughly -1…1.
+    /// Smoothed front/back recline transient, roughly -1…1. Decays to 0 at rest.
     private(set) var tiltY: Double = 0
 
     @ObservationIgnored private let manager = CMMotionManager()
-    @ObservationIgnored private var referenceLean: Double?
-    @ObservationIgnored private var referenceRecline: Double?
+    @ObservationIgnored private var baselineLean: Double?
+    @ObservationIgnored private var baselineRecline: Double?
     @ObservationIgnored private var isRunning = false
 
-    /// Tilt of this many radians from rest maps to the full ±1 range (~20°).
-    private let maxTilt: Double = 0.35
+    /// A transient of this many radians maps to the full ±1 range. Smaller =
+    /// gentler moves reach full parallax.
+    private let maxTilt: Double = 0.2
+    /// How fast the neutral baseline drifts toward the current pose — i.e. how
+    /// quickly a held tilt returns to base. Larger = snappier return (and
+    /// demands quicker motion to register). ~0.04 ≈ settles in roughly a second.
+    private let baselineFollow: Double = 0.04
     /// Low-pass blend per sample. Lower = smoother but laggier.
     private let smoothing: Double = 0.12
     /// Skip publishing sub-pixel changes so a still device doesn't redraw.
@@ -42,8 +53,8 @@ final class MotionStore {
     func start() {
         guard !isRunning, manager.isDeviceMotionAvailable else { return }
         isRunning = true
-        referenceLean = nil
-        referenceRecline = nil
+        baselineLean = nil
+        baselineRecline = nil
         manager.deviceMotionUpdateInterval = 1.0 / 60.0
         manager.startDeviceMotionUpdates(to: .main) { [weak self] motion, _ in
             guard let motion else { return }
@@ -57,8 +68,8 @@ final class MotionStore {
         guard isRunning else { return }
         isRunning = false
         manager.stopDeviceMotionUpdates()
-        referenceLean = nil
-        referenceRecline = nil
+        baselineLean = nil
+        baselineRecline = nil
         // Recenter so the stack doesn't keep a stale offset while parallax is off.
         tiltX = 0
         tiltY = 0
@@ -73,14 +84,24 @@ final class MotionStore {
         // angle within the Y–Z plane. ~0 when upright, →π/2 when flat.
         let recline = atan2(-g.z, -g.y)
 
-        if referenceLean == nil {
-            referenceLean = lean
-            referenceRecline = recline
+        // First sample seeds the baseline so we don't fire a transient on start.
+        if baselineLean == nil {
+            baselineLean = lean
+            baselineRecline = recline
         }
-        guard let referenceLean, let referenceRecline else { return }
+        guard var bLean = baselineLean, var bRecline = baselineRecline else { return }
 
-        let newX = tiltX + (clampNorm(lean - referenceLean) - tiltX) * smoothing
-        let newY = tiltY + (clampNorm(recline - referenceRecline) - tiltY) * smoothing
+        // High-pass: ease the baseline toward the current pose so a sustained
+        // tilt is absorbed (returns to base) while a quick move produces a
+        // transient. The published value is the current pose minus this
+        // drifting baseline.
+        bLean += (lean - bLean) * baselineFollow
+        bRecline += (recline - bRecline) * baselineFollow
+        baselineLean = bLean
+        baselineRecline = bRecline
+
+        let newX = tiltX + (clampNorm(lean - bLean) - tiltX) * smoothing
+        let newY = tiltY + (clampNorm(recline - bRecline) - tiltY) * smoothing
         if abs(newX - tiltX) > epsilon { tiltX = newX }
         if abs(newY - tiltY) > epsilon { tiltY = newY }
     }

--- a/Hibi/Models/MotionStore.swift
+++ b/Hibi/Models/MotionStore.swift
@@ -39,14 +39,21 @@ final class MotionStore {
     @ObservationIgnored private var isRunning = false
 
     /// A transient of this many radians maps to the full ±1 range. Smaller =
-    /// gentler moves reach full parallax.
-    private let maxTilt: Double = 0.2
+    /// gentler moves reach full parallax. Kept low because the high-pass below
+    /// shrinks the transient (the baseline eats part of every move).
+    private let maxTilt: Double = 0.1
     /// How fast the neutral baseline drifts toward the current pose — i.e. how
-    /// quickly a held tilt returns to base. Larger = snappier return (and
-    /// demands quicker motion to register). ~0.04 ≈ settles in roughly a second.
-    private let baselineFollow: Double = 0.04
-    /// Low-pass blend per sample. Lower = smoother but laggier.
-    private let smoothing: Double = 0.12
+    /// quickly a held tilt returns to base. Larger = snappier return. ~0.1 ≈
+    /// settles in about half a second.
+    private let baselineFollow: Double = 0.1
+    /// Output low-pass blend per sample. Higher = crisper / less lag behind the
+    /// move; lower = smoother but floatier. The gravity signal is already
+    /// fusion-smoothed, so this can run high without visible jitter.
+    private let smoothing: Double = 0.35
+    /// Transients below this many radians are ignored, so sensor noise and tiny
+    /// unintentional wobbles don't register — only deliberate motion does. The
+    /// knee is soft (threshold subtracted, not a hard cut) so there's no notch.
+    private let deadzone: Double = 0.01
     /// Skip publishing sub-pixel changes so a still device doesn't redraw.
     private let epsilon: Double = 0.0008
 
@@ -100,13 +107,19 @@ final class MotionStore {
         baselineLean = bLean
         baselineRecline = bRecline
 
-        let newX = tiltX + (clampNorm(lean - bLean) - tiltX) * smoothing
-        let newY = tiltY + (clampNorm(recline - bRecline) - tiltY) * smoothing
+        let newX = tiltX + (shape(lean - bLean) - tiltX) * smoothing
+        let newY = tiltY + (shape(recline - bRecline) - tiltY) * smoothing
         if abs(newX - tiltX) > epsilon { tiltX = newX }
         if abs(newY - tiltY) > epsilon { tiltY = newY }
     }
 
-    private func clampNorm(_ radians: Double) -> Double {
-        max(-1, min(1, radians / maxTilt))
+    /// Soft dead zone + normalize to ±1: subtract the dead-zone threshold (so
+    /// the curve stays continuous from zero, no notch), then scale the
+    /// remaining range up to maxTilt.
+    private func shape(_ radians: Double) -> Double {
+        let magnitude = abs(radians) - deadzone
+        guard magnitude > 0 else { return 0 }
+        let normalized = min(1, magnitude / (maxTilt - deadzone))
+        return radians < 0 ? -normalized : normalized
     }
 }

--- a/Hibi/Models/MotionStore.swift
+++ b/Hibi/Models/MotionStore.swift
@@ -1,0 +1,76 @@
+import CoreMotion
+import Observation
+
+/// Observable device-tilt source for the Day view's paper-stack parallax.
+///
+/// Reports tilt **relative to the orientation the device was in when `start()`
+/// was called** — the reference attitude is captured on the first sample and
+/// every later sample is expressed as a delta from it (`multiply(byInverseOf:)`).
+/// That makes "however you're holding the phone right now" the neutral pose, so
+/// the stack rests centered regardless of whether you're upright on a couch or
+/// flat on a desk.
+///
+/// `tiltX`/`tiltY` are low-pass filtered and gated by a small epsilon so a
+/// perfectly still device produces no SwiftUI invalidations. Device motion needs
+/// no authorization and no Info.plist key (unlike CMMotionActivity), so starting
+/// it never prompts the user.
+@MainActor
+@Observable
+final class MotionStore {
+    /// Smoothed left/right tilt (roll) from rest, roughly -1…1.
+    private(set) var tiltX: Double = 0
+    /// Smoothed forward/back tilt (pitch) from rest, roughly -1…1.
+    private(set) var tiltY: Double = 0
+
+    @ObservationIgnored private let manager = CMMotionManager()
+    @ObservationIgnored private var reference: CMAttitude?
+    @ObservationIgnored private var isRunning = false
+
+    /// Tilt of this many radians from rest maps to the full ±1 range (~20°).
+    private let maxTilt: Double = 0.35
+    /// Low-pass blend per sample. Lower = smoother but laggier.
+    private let smoothing: Double = 0.12
+    /// Skip publishing sub-pixel changes so a still device doesn't redraw.
+    private let epsilon: Double = 0.0008
+
+    func start() {
+        guard !isRunning, manager.isDeviceMotionAvailable else { return }
+        isRunning = true
+        reference = nil
+        manager.deviceMotionUpdateInterval = 1.0 / 60.0
+        manager.startDeviceMotionUpdates(to: .main) { [weak self] motion, _ in
+            guard let motion else { return }
+            MainActor.assumeIsolated {
+                self?.ingest(motion)
+            }
+        }
+    }
+
+    func stop() {
+        guard isRunning else { return }
+        isRunning = false
+        manager.stopDeviceMotionUpdates()
+        reference = nil
+        // Recenter so the stack doesn't keep a stale offset while parallax is off.
+        tiltX = 0
+        tiltY = 0
+    }
+
+    private func ingest(_ motion: CMDeviceMotion) {
+        let attitude = motion.attitude
+        if reference == nil {
+            reference = attitude.copy() as? CMAttitude
+        }
+        guard let reference, let current = attitude.copy() as? CMAttitude else { return }
+        current.multiply(byInverseOf: reference)
+
+        let newX = tiltX + (clampNorm(current.roll) - tiltX) * smoothing
+        let newY = tiltY + (clampNorm(current.pitch) - tiltY) * smoothing
+        if abs(newX - tiltX) > epsilon { tiltX = newX }
+        if abs(newY - tiltY) > epsilon { tiltY = newY }
+    }
+
+    private func clampNorm(_ radians: Double) -> Double {
+        max(-1, min(1, radians / maxTilt))
+    }
+}

--- a/Hibi/Models/MotionStore.swift
+++ b/Hibi/Models/MotionStore.swift
@@ -4,11 +4,16 @@ import Observation
 /// Observable device-tilt source for the Day view's paper-stack parallax.
 ///
 /// Reports tilt **relative to the orientation the device was in when `start()`
-/// was called** — the reference attitude is captured on the first sample and
-/// every later sample is expressed as a delta from it (`multiply(byInverseOf:)`).
-/// That makes "however you're holding the phone right now" the neutral pose, so
-/// the stack rests centered regardless of whether you're upright on a couch or
-/// flat on a desk.
+/// was called** — a reference pose is captured on the first sample and every
+/// later sample is expressed as a delta from it. That makes "however you're
+/// holding the phone right now" the neutral pose, so the stack rests centered
+/// whether you're upright on a couch or flat on a desk.
+///
+/// Tilt is derived from the **gravity vector**, not the attitude's Euler
+/// angles. Euler `pitch`/`roll` degenerate (gimbal lock) when the phone is held
+/// near-vertical — which is exactly the Day-view reading pose — so front/back
+/// tilt would read as zero there. The gravity vector stays well-defined at any
+/// orientation, giving two decoupled, responsive tilt axes.
 ///
 /// `tiltX`/`tiltY` are low-pass filtered and gated by a small epsilon so a
 /// perfectly still device produces no SwiftUI invalidations. Device motion needs
@@ -17,13 +22,14 @@ import Observation
 @MainActor
 @Observable
 final class MotionStore {
-    /// Smoothed left/right tilt (roll) from rest, roughly -1…1.
+    /// Smoothed left/right lean from rest, roughly -1…1.
     private(set) var tiltX: Double = 0
-    /// Smoothed forward/back tilt (pitch) from rest, roughly -1…1.
+    /// Smoothed front/back recline from rest, roughly -1…1.
     private(set) var tiltY: Double = 0
 
     @ObservationIgnored private let manager = CMMotionManager()
-    @ObservationIgnored private var reference: CMAttitude?
+    @ObservationIgnored private var referenceLean: Double?
+    @ObservationIgnored private var referenceRecline: Double?
     @ObservationIgnored private var isRunning = false
 
     /// Tilt of this many radians from rest maps to the full ±1 range (~20°).
@@ -36,7 +42,8 @@ final class MotionStore {
     func start() {
         guard !isRunning, manager.isDeviceMotionAvailable else { return }
         isRunning = true
-        reference = nil
+        referenceLean = nil
+        referenceRecline = nil
         manager.deviceMotionUpdateInterval = 1.0 / 60.0
         manager.startDeviceMotionUpdates(to: .main) { [weak self] motion, _ in
             guard let motion else { return }
@@ -50,22 +57,30 @@ final class MotionStore {
         guard isRunning else { return }
         isRunning = false
         manager.stopDeviceMotionUpdates()
-        reference = nil
+        referenceLean = nil
+        referenceRecline = nil
         // Recenter so the stack doesn't keep a stale offset while parallax is off.
         tiltX = 0
         tiltY = 0
     }
 
     private func ingest(_ motion: CMDeviceMotion) {
-        let attitude = motion.attitude
-        if reference == nil {
-            reference = attitude.copy() as? CMAttitude
-        }
-        guard let reference, let current = attitude.copy() as? CMAttitude else { return }
-        current.multiply(byInverseOf: reference)
+        let g = motion.gravity
+        // Left/right lean: gravity's angle out of the device's Y–Z plane.
+        // ~0 when held straight, grows as the phone leans to either side.
+        let lean = atan2(g.x, hypot(g.y, g.z))
+        // Front/back recline (tilting the bottom up / top back): gravity's
+        // angle within the Y–Z plane. ~0 when upright, →π/2 when flat.
+        let recline = atan2(-g.z, -g.y)
 
-        let newX = tiltX + (clampNorm(current.roll) - tiltX) * smoothing
-        let newY = tiltY + (clampNorm(current.pitch) - tiltY) * smoothing
+        if referenceLean == nil {
+            referenceLean = lean
+            referenceRecline = recline
+        }
+        guard let referenceLean, let referenceRecline else { return }
+
+        let newX = tiltX + (clampNorm(lean - referenceLean) - tiltX) * smoothing
+        let newY = tiltY + (clampNorm(recline - referenceRecline) - tiltY) * smoothing
         if abs(newX - tiltX) > epsilon { tiltX = newX }
         if abs(newY - tiltY) > epsilon { tiltY = newY }
     }

--- a/Hibi/Views/DayView.swift
+++ b/Hibi/Views/DayView.swift
@@ -72,7 +72,7 @@ struct DayView: View {
     /// Max parallax travel (pts) for the front card at full tilt. Deeper cards
     /// scale down from this, so the front drifts farther than the back and the
     /// stack reads with depth. Kept intentionally small — "very slight."
-    private let parallaxMaxOffset: CGFloat = 7
+    private let parallaxMaxOffset: CGFloat = 4
 
     // Schedule-collapse geometry. The paper stack and the "Pull to tear" hint
     // shrink toward `…Collapsed` values as scheduleProgress → 1. Drag range

--- a/Hibi/Views/DayView.swift
+++ b/Hibi/Views/DayView.swift
@@ -17,6 +17,13 @@ struct DayView: View {
     @Environment(WeatherStore.self) private var weatherStore
     @Environment(Clock.self) private var clock
     @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.scenePhase) private var scenePhase
+    /// Drives the gyro parallax on the paper stack. Owned locally — only the
+    /// Day view uses it, so there's no need to inject it app-wide. Started on
+    /// appear / scene-active and stopped on disappear / background / Reduce
+    /// Motion so the gyro isn't running when the stack isn't on screen.
+    @State private var motion = MotionStore()
     @AppStorage("invertDaySwipe") private var invertDaySwipe: Bool = false
     @AppStorage("preferCompactDayView") private var preferCompactDayView: Bool = false
     @AppStorage("useSimpleFont", store: AppGroup.defaults) private var useSimpleFont: Bool = false
@@ -61,6 +68,11 @@ struct DayView: View {
     private let narrowStep: CGFloat = 14      // pts narrower per side per depth level
     private let tearThreshold: CGFloat = 80
     private let offScreen: CGFloat = 700
+
+    /// Max parallax travel (pts) for the front card at full tilt. Deeper cards
+    /// scale down from this, so the front drifts farther than the back and the
+    /// stack reads with depth. Kept intentionally small — "very slight."
+    private let parallaxMaxOffset: CGFloat = 7
 
     // Schedule-collapse geometry. The paper stack and the "Pull to tear" hint
     // shrink toward `…Collapsed` values as scheduleProgress → 1. Drag range
@@ -148,6 +160,20 @@ struct DayView: View {
                 scheduleProgress = target
             }
         }
+        // Gyro parallax lifecycle. Only run the motion manager while the Day
+        // view is on screen and the app is active, and never under Reduce Motion.
+        .onAppear { updateMotion() }
+        .onDisappear { motion.stop() }
+        .onChange(of: scenePhase) { _, _ in updateMotion() }
+        .onChange(of: reduceMotion) { _, _ in updateMotion() }
+    }
+
+    private func updateMotion() {
+        if scenePhase == .active && !reduceMotion {
+            motion.start()
+        } else {
+            motion.stop()
+        }
     }
 
     private var scrollFadeMask: some View {
@@ -218,6 +244,20 @@ struct DayView: View {
         return max(0, amount)
     }
 
+    /// Gyro parallax for a card at the given stack depth (0 = front). Applied
+    /// via a dedicated `ViewModifier` rather than reading `motion` here in the
+    /// body: the modifier scopes the ~60 Hz tilt observation to the offset
+    /// alone, so a gyro tick doesn't re-run the paper-card builders or the
+    /// schedule list (and its hosted scroll view) every frame.
+    private func parallax(depth: Int) -> ParallaxOffset {
+        ParallaxOffset(
+            motion: motion,
+            depth: depth,
+            maxOffset: parallaxMaxOffset,
+            reduceMotion: reduceMotion
+        )
+    }
+
     private var pullToTearHint: some View {
         Text(invertDaySwipe
              ? "Pull to tear · ↑ Prev · ↓ Next"
@@ -258,6 +298,7 @@ struct DayView: View {
                     shadowAmount: 0,
                     chromeAmount: 0
                 )
+                .modifier(parallax(depth: 3))
                 .opacity(goingForward ? cardShiftAmount : 0)
 
                 // Card 3 (back): rest inset = 2·narrowStep, peek = 0.
@@ -275,6 +316,7 @@ struct DayView: View {
                     shadowAmount: 0,
                     chromeAmount: 0
                 )
+                .modifier(parallax(depth: 2))
                 .opacity(goingForward ? 1 : 1 - cardShiftAmount)
 
                 // Card 2 (middle): rest inset = narrowStep, peek = peekAmount.
@@ -294,6 +336,7 @@ struct DayView: View {
                     shadowAmount: goingForward ? Double(cardShiftAmount) : 0,
                     chromeAmount: goingForward ? Double(cardShiftAmount) : 0
                 )
+                .modifier(parallax(depth: 1))
 
                 // Card 1 (front): widest, shortest.
                 // Forward: slides off via dragY.
@@ -316,6 +359,7 @@ struct DayView: View {
                     goingForward ? .degrees(Double(dragY * 0.02)) : .zero,
                     anchor: dragY > 0 ? .top : .bottom
                 )
+                .modifier(parallax(depth: 0))
                 .opacity(goingForward ? 1 - min(Double(abs(dragY)) / 400, 0.6) : 1)
                 .gesture(
                     DragGesture()
@@ -359,6 +403,7 @@ struct DayView: View {
                 .degrees(abs(incomingCardY) > 10 ? Double(incomingCardY) * 0.005 : 0),
                 anchor: incomingCardY < 0 ? .bottom : .top
             )
+            .modifier(parallax(depth: 0))
             .opacity(max(0, 1 - abs(incomingCardY) / 400))
             .allowsHitTesting(false)
         }
@@ -745,5 +790,33 @@ struct DayView: View {
         } else {
             day = target.day
         }
+    }
+}
+
+/// Translates a paper card by the gyro tilt for its stack depth. The tilt is
+/// read inside `body(content:)` so the ~60 Hz observation is confined to this
+/// modifier — `content` is the already-built card, reused untouched, so a gyro
+/// tick never re-runs the card builder or the surrounding Day-view body.
+///
+/// Nearer cards (lower depth) drift farther than deeper ones, which is what
+/// reads as parallax. Signs map roll → x and pitch → y; negate a component
+/// here if the on-device direction feels inverted. A no-op under Reduce Motion.
+private struct ParallaxOffset: ViewModifier {
+    let motion: MotionStore
+    let depth: Int
+    let maxOffset: CGFloat
+    let reduceMotion: Bool
+
+    func body(content: Content) -> some View {
+        content.offset(offset)
+    }
+
+    private var offset: CGSize {
+        guard !reduceMotion else { return .zero }
+        let factor = max(0.25, 1 - CGFloat(depth) * 0.25)
+        return CGSize(
+            width: CGFloat(motion.tiltX) * maxOffset * factor,
+            height: CGFloat(motion.tiltY) * maxOffset * factor
+        )
     }
 }

--- a/Hibi/Views/DayView.swift
+++ b/Hibi/Views/DayView.swift
@@ -799,8 +799,9 @@ struct DayView: View {
 /// tick never re-runs the card builder or the surrounding Day-view body.
 ///
 /// Nearer cards (lower depth) drift farther than deeper ones, which is what
-/// reads as parallax. Signs map roll → x and pitch → y; negate a component
-/// here if the on-device direction feels inverted. A no-op under Reduce Motion.
+/// reads as parallax. `tiltX` is left/right lean, `tiltY` is front/back
+/// recline; negate a component here if the on-device direction feels inverted.
+/// A no-op under Reduce Motion.
 private struct ParallaxOffset: ViewModifier {
     let motion: MotionStore
     let depth: Int


### PR DESCRIPTION
Implements device-motion-driven parallax on the paper card stack, creating a subtle depth effect that responds to device tilt. The parallax is only active when the Day view is visible and the app is in the foreground, and respects the system's Reduce Motion accessibility setting.

## Changes

- **New `MotionStore` class**: Observable CoreMotion wrapper that captures device tilt relative to a reference attitude (the device's orientation when motion tracking starts). Provides low-pass filtered `tiltX` and `tiltY` values that map device roll/pitch to roughly ±1 range. Includes epsilon gating to prevent SwiftUI invalidations from imperceptible motion.

- **Day view motion lifecycle**: Added `@State` `MotionStore` instance owned locally by DayView. Motion tracking is started/stopped based on scene phase (active/background) and accessibility settings (Reduce Motion). Lifecycle hooks ensure the gyro isn't running when the stack isn't visible.

- **New `ParallaxOffset` view modifier**: Applies gyro-driven offset to individual cards based on their stack depth. Nearer cards (lower depth) drift farther than deeper ones, creating the parallax illusion. The modifier scopes the ~60 Hz motion observation to offset calculation alone, preventing gyro ticks from re-running card builders or the schedule list.

- **Card stack integration**: Applied `ParallaxOffset` modifier to all four visible cards (front, middle, back, and incoming) with appropriate depth values.

## Implementation notes

- Reference attitude is captured on first motion sample and all subsequent samples are expressed as deltas from it, making "however you're holding the phone right now" the neutral pose.
- Parallax offset is intentionally small (7 pts max at full tilt) for a subtle effect.
- The modifier-based approach isolates motion observation to offset calculation, avoiding unnecessary re-renders of expensive card builders.

https://claude.ai/code/session_01CA6e8h7FHtahnVydHCRb6t