### PR TITLE
Move Debug section to bottom of Settings

### DIFF
--- a/Hibi/Views/SettingsView.swift
+++ b/Hibi/Views/SettingsView.swift
@@ -51,18 +51,6 @@ struct SettingsView: View {
                     }
                 }
 
-                #if DEBUG
-                Section("Debug") {
-                    Toggle(isOn: Binding(
-                        get: { eventStore.isDemoMode },
-                        set: { eventStore.setDemoMode($0) }
-                    )) {
-                        Label("Demo Mode", systemImage: "wand.and.stars")
-                    }
-                    .tint(.black)
-                }
-                #endif
-
                 if hasMissingPermission {
                     Section("Permissions") {
                         Button {
@@ -115,6 +103,18 @@ struct SettingsView: View {
                         }
                     }
                 }
+
+                #if DEBUG
+                Section("Debug") {
+                    Toggle(isOn: Binding(
+                        get: { eventStore.isDemoMode },
+                        set: { eventStore.setDemoMode($0) }
+                    )) {
+                        Label("Demo Mode", systemImage: "wand.and.stars")
+                    }
+                    .tint(.black)
+                }
+                #endif
             }
             .navigationTitle("Settings")
             .toolbar {


### PR DESCRIPTION
## Summary
Reordered the Debug section in SettingsView to appear at the bottom of the settings list, after all other sections including the About section.

## Changes
- Moved the `#if DEBUG` Debug section from its position after the initial settings to the end of the Form, placing it after the About section
- The Debug section's functionality and content remain unchanged—only its visual position in the settings hierarchy has been adjusted

## Rationale
This change improves the settings layout by placing debug-only features at the bottom where they're less prominent, keeping primary user-facing settings and information (Permissions, About) in more prominent positions.

https://claude.ai/code/session_01BqM2SatnHrUxZVjV6SNvXV