### PR TITLE
Add top-edge fade to Settings scroll list

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,3 +3,7 @@
 Project orientation lives in [AGENTS.md](AGENTS.md) — read it first. It has the one-paragraph "what this is," the tech stack / deployment target, the architecture sketch, a file index grouped by role, and the conventions/gotchas that aren't obvious from the code.
 
 Come back here only for Claude-specific notes; everything project-level belongs in `AGENTS.md`.
+
+## Build & verification
+
+- **Do NOT use the simulator.** The user tests on a physical device. Build-only (`build_sim` or `xcodebuild build`) to verify compilation, but never launch, run, or deploy to a simulator.

--- a/Hibi/Views/SettingsView.swift
+++ b/Hibi/Views/SettingsView.swift
@@ -120,6 +120,15 @@ struct SettingsView: View {
             }
             #endif
             }
+            .overlay(alignment: .top) {
+                LinearGradient(
+                    colors: [Color(.systemGroupedBackground),
+                             Color(.systemGroupedBackground).opacity(0)],
+                    startPoint: .top, endPoint: .bottom
+                )
+                .frame(height: 24)
+                .allowsHitTesting(false)
+            }
         }
         .navigationTitle(Text(verbatim: "Hibi"))
         .noteletSheet(


### PR DESCRIPTION
## Summary
- Settings rows now fade smoothly under the Hibi Plus card as they scroll up, matching the existing fade pattern in the Day tab schedule.
- Uses an overlay `LinearGradient` with `systemGroupedBackground` so the fade color adapts automatically to both light and dark mode.
- Adds a no-simulator build note to `CLAUDE.md`.

## Test plan
- [ ] Open Settings tab and scroll the form up — rows should fade smoothly under the Hibi Plus card area
- [ ] Verify in light mode (grey background matches)
- [ ] Verify in dark mode (dark background matches)
- [ ] Confirm taps still work on rows near the top edge (overlay has `allowsHitTesting(false)`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)