### PR TITLE
Fix Hibi Plus card content clipping at edges

### DIFF
--- a/Hibi/Views/HibiPlusView.swift
+++ b/Hibi/Views/HibiPlusView.swift
@@ -173,16 +173,18 @@ struct AppIconCarousel: View {
             let elapsed = context.date.timeIntervalSinceReferenceDate
             let raw = CGFloat(elapsed) * speed
             let offset = -(raw.truncatingRemainder(dividingBy: unitWidth))
-            HStack(spacing: spacing) {
-                ForEach(0..<(count * 3), id: \.self) { _ in
-                    AppIconTile(size: size)
+            Color.clear
+                .overlay {
+                    HStack(spacing: spacing) {
+                        ForEach(0..<(count * 3), id: \.self) { _ in
+                            AppIconTile(size: size)
+                        }
+                    }
+                    .offset(x: offset)
                 }
-            }
-            .offset(x: offset)
+                .clipped()
         }
         .frame(height: size)
-        .frame(maxWidth: .infinity)
-        .clipShape(Rectangle())
         .mask(
             LinearGradient(
                 stops: [
@@ -484,7 +486,7 @@ private struct FeatureCardBody: View {
                 .padding(.bottom, expanded ? 0 : 22)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .padding(.horizontal, expanded ? 16 : 0)
+        .padding(.horizontal, 16)
         .padding(.top, 8)
     }
 


### PR DESCRIPTION
## Summary
- The `AppIconCarousel`'s wide HStack (~1269pt) was propagating its natural width through `.frame(maxWidth: .infinity)`, bloating the card body beyond the visible clip bounds
- Wrapped the HStack in a `Color.clear` overlay so the carousel adopts the proposed width instead of the child's natural width
- Made `FeatureCardBody` horizontal padding unconditional (always 16pt) so content stays inset in both collapsed and expanded states

## Test plan
- [ ] Build and run on device
- [ ] Verify Hibi Plus card content (carousel, perks, CTA) fits inside card edges in both collapsed and expanded states
- [ ] Check carousel animation still scrolls smoothly with fade mask
- [ ] Verify collapsed card text is properly inset

🤖 Generated with [Claude Code](https://claude.com/claude-code)