### PR TITLE
Scroll-driven paper collapse in Settings with smooth transitions

### DIFF
--- a/Hibi/Views/Components/HijackingScrollView.swift
+++ b/Hibi/Views/Components/HijackingScrollView.swift
@@ -21,6 +21,10 @@ struct HijackingScrollView<Content: View>: UIViewRepresentable {
     var onSnap: (() -> Void)? = nil
     @ViewBuilder var content: () -> Content
 
+    static var snapSpring: Animation {
+        .spring(response: 0.38, dampingFraction: 0.86)
+    }
+
     func makeCoordinator() -> Coordinator {
         let binding = $progress
         return Coordinator(
@@ -35,7 +39,7 @@ struct HijackingScrollView<Content: View>: UIViewRepresentable {
             },
             snapProgress: { target in
                 var t = Transaction()
-                t.animation = .spring(response: 0.38, dampingFraction: 0.86)
+                t.animation = HijackingScrollView.snapSpring
                 t.scrollContentOffsetAdjustmentBehavior = .disabled
                 withTransaction(t) { binding.wrappedValue = target }
             },
@@ -86,7 +90,7 @@ struct HijackingScrollView<Content: View>: UIViewRepresentable {
         }
         context.coordinator.snapProgress = { target in
             var t = Transaction()
-            t.animation = .spring(response: 0.38, dampingFraction: 0.86)
+            t.animation = HijackingScrollView.snapSpring
             t.scrollContentOffsetAdjustmentBehavior = .disabled
             withTransaction(t) { binding.wrappedValue = target }
         }

--- a/Hibi/Views/HibiPlusView.swift
+++ b/Hibi/Views/HibiPlusView.swift
@@ -757,9 +757,6 @@ struct HibiPlusView: View {
     // 0 = stamp card, 1 = feature card
     @State private var frontIndex = 0
     @Binding var collapseProgress: CGFloat
-    init(collapseProgress: Binding<CGFloat> = .constant(1)) {
-        self._collapseProgress = collapseProgress
-    }
     private var expanded: Bool { collapseProgress < 0.5 }
     private var chromeFade: Double {
         Double(max(0, 1 - collapseProgress * 1.25))

--- a/Hibi/Views/HibiPlusView.swift
+++ b/Hibi/Views/HibiPlusView.swift
@@ -602,13 +602,14 @@ private struct StampCardBody: View {
     let purchased: Bool
     let date: Date?
     let expanded: Bool
+    let expandFraction: CGFloat
     let stampToken: Int
     @AppStorage("useSimpleFont", store: AppGroup.defaults) private var useSimpleFont = false
 
     var body: some View {
         VStack(spacing: 18) {
             HibiStamp(purchased: purchased, date: date,
-                      size: expanded ? 310 : 200, stampToken: stampToken)
+                      size: 200 + 110 * expandFraction, stampToken: stampToken)
             if expanded && !purchased {
                 Text("Purchase Hibi Plus to receive your personalized seal.")
                     .font(.appSerif(size: 15, italic: true, simple: useSimpleFont))
@@ -627,11 +628,10 @@ private struct StampCardBody: View {
 private struct FeatureCardBody: View {
     let purchased: Bool
     let expanded: Bool
+    let chromeFade: Double
     @Binding var ctaSuccess: Bool
     let onPurchase: () -> Void
     @AppStorage("useSimpleFont", store: AppGroup.defaults) private var useSimpleFont = false
-
-    private var chromeFade: Double { expanded ? 1 : 0 }
 
     var body: some View {
         VStack(spacing: 0) {
@@ -756,7 +756,14 @@ private struct FeatureCardBody: View {
 struct HibiPlusView: View {
     // 0 = stamp card, 1 = feature card
     @State private var frontIndex = 0
-    @State private var expanded = false
+    @Binding var collapseProgress: CGFloat
+    init(collapseProgress: Binding<CGFloat> = .constant(1)) {
+        self._collapseProgress = collapseProgress
+    }
+    private var expanded: Bool { collapseProgress < 0.5 }
+    private var chromeFade: Double {
+        Double(max(0, 1 - collapseProgress * 1.25))
+    }
     @State private var isPlus = false
     @State private var purchaseDate: Date?
 
@@ -781,10 +788,11 @@ struct HibiPlusView: View {
     var body: some View {
         GeometryReader { geo in
             let w = geo.size.width
-            let frontW = expanded ? w - 32 : HPLayout.collapsed.width
-            let frontH = expanded ? expandedHeight(for: frontIndex) : HPLayout.collapsed.height
-            let backW = expanded ? w - 32 : HPLayout.collapsed.width
-            let backH = expanded ? expandedHeight(for: backIndex) : HPLayout.collapsed.height
+            let ef = 1 - collapseProgress
+            let frontW = HPLayout.collapsed.width + (w - 32 - HPLayout.collapsed.width) * ef
+            let frontH = HPLayout.collapsed.height + (expandedHeight(for: frontIndex) - HPLayout.collapsed.height) * ef
+            let backW = HPLayout.collapsed.width + (w - 32 - HPLayout.collapsed.width) * ef
+            let backH = HPLayout.collapsed.height + (expandedHeight(for: backIndex) - HPLayout.collapsed.height) * ef
             let stackW = lerp(frontW, backW, cardShift)
             let stackH = lerp(frontH, backH, cardShift)
             VStack(spacing: 0) {
@@ -796,15 +804,16 @@ struct HibiPlusView: View {
             .frame(width: w)
         }
         .frame(height: totalHeight)
-        .animation(HPLayout.collapseSpring, value: expanded)
         .animation(HPLayout.collapseSpring, value: isPlus)
     }
 
     private var totalHeight: CGFloat {
-        let frontH = expanded ? expandedHeight(for: frontIndex) : HPLayout.collapsed.height
-        let backH = expanded ? expandedHeight(for: backIndex) : HPLayout.collapsed.height
+        let ef = 1 - collapseProgress
+        let frontH = HPLayout.collapsed.height + (expandedHeight(for: frontIndex) - HPLayout.collapsed.height) * ef
+        let backH = HPLayout.collapsed.height + (expandedHeight(for: backIndex) - HPLayout.collapsed.height) * ef
         let h = lerp(frontH, backH, cardShift)
-        return h + 14 + HPLayout.hintHeight
+        let hintH = HPLayout.hintHeight * ef
+        return h + 14 + hintH
     }
 
     @ViewBuilder
@@ -936,18 +945,24 @@ struct HibiPlusView: View {
     private func cardBody(index: Int) -> some View {
         if index == 0 {
             StampCardBody(purchased: isPlus, date: purchaseDate,
-                          expanded: expanded, stampToken: stampToken)
+                          expanded: expanded, expandFraction: 1 - collapseProgress,
+                          stampToken: stampToken)
         } else {
             FeatureCardBody(purchased: isPlus, expanded: expanded,
+                            chromeFade: chromeFade,
                             ctaSuccess: $ctaSuccess, onPurchase: purchase)
         }
     }
 
     private var hint: some View {
-        Text("Pull to tear · ↑ Next · ↓ Prev")
+        let ef = 1 - collapseProgress
+        return Text("Pull to tear · ↑ Next · ↓ Prev")
             .font(.appSerif(size: 13, italic: true, simple: useSimpleFont))
             .foregroundStyle(.tertiary)
             .frame(maxWidth: .infinity)
+            .frame(height: HPLayout.hintHeight * ef)
+            .opacity(chromeFade)
+            .clipped()
     }
 
     // MARK: gestures
@@ -969,7 +984,11 @@ struct HibiPlusView: View {
 
     private func toggleExpand() {
         guard !isAnimating else { return }
-        withAnimation(HPLayout.collapseSpring) { expanded.toggle() }
+        let target: CGFloat = collapseProgress >= 0.5 ? 0 : 1
+        var t = Transaction()
+        t.animation = HijackingScrollView<EmptyView>.snapSpring
+        t.scrollContentOffsetAdjustmentBehavior = .disabled
+        withTransaction(t) { collapseProgress = target }
     }
 
     /// Flip to the other card, sliding the front off in `direction`
@@ -1012,7 +1031,7 @@ struct HibiPlusView: View {
                     withTransaction(t) {
                         frontIndex = 0
                         dragY = 0; cardShift = 0; isAnimating = false
-                        expanded = false
+                        collapseProgress = 1
                     }
                     ctaSuccess = false
                     // 3) stamp the seal after the card has settled
@@ -1021,7 +1040,7 @@ struct HibiPlusView: View {
                     }
                 }
             } else {
-                expanded = false
+                collapseProgress = 1
                 ctaSuccess = false
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.45) {
                     stampToken &+= 1

--- a/Hibi/Views/HibiPlusView.swift
+++ b/Hibi/Views/HibiPlusView.swift
@@ -477,10 +477,13 @@ struct EarlyAccessTile: View {
                 RadarPingIndicator()
                 Text("Currently in early access")
                     .font(.system(size: 10, weight: .semibold))
+                    .lineLimit(1)
                 Spacer()
                 Text("\(daysLeft) days left")
                     .font(.system(size: 10, weight: .medium, design: .monospaced))
                     .foregroundStyle(.tertiary)
+                    .lineLimit(1)
+                    .layoutPriority(1)
             }
             .padding(.horizontal, 12)
             .padding(.vertical, 9)
@@ -493,9 +496,11 @@ struct EarlyAccessTile: View {
                 VStack(alignment: .leading, spacing: 2) {
                     Text("Widgets")
                         .font(.custom(AppFont.serifRegular, size: 18))
+                        .lineLimit(1)
                     Text("On your home screen — paper, every day.")
                         .font(.custom(AppFont.serifItalic, size: 11.5))
                         .foregroundStyle(.tertiary)
+                        .lineLimit(1)
                 }
                 Spacer(minLength: 0)
             }
@@ -571,7 +576,7 @@ struct RestorePurchasesLink: View {
 
 private struct PlusHeader: View {
     var deck: LocalizedStringKey?
-    var showDeck: Bool = false
+    var deckFade: Double = 0
     @AppStorage("useSimpleFont", store: AppGroup.defaults) private var useSimpleFont = false
     var body: some View {
         VStack(spacing: 4) {
@@ -586,11 +591,9 @@ private struct PlusHeader: View {
                 Text(deck)
                     .font(.appSerif(size: 13.5, italic: true, simple: useSimpleFont))
                     .foregroundStyle(.tertiary)
-                    .multilineTextAlignment(.center)
+                    .lineLimit(1)
                     .padding(.top, 2)
-                    .opacity(showDeck ? 1 : 0)
-                    .frame(height: showDeck ? nil : 0)
-                    .clipped()
+                    .opacity(deckFade)
             }
         }
     }
@@ -601,8 +604,8 @@ private struct PlusHeader: View {
 private struct StampCardBody: View {
     let purchased: Bool
     let date: Date?
-    let expanded: Bool
     let expandFraction: CGFloat
+    let chromeFade: Double
     let stampToken: Int
     @AppStorage("useSimpleFont", store: AppGroup.defaults) private var useSimpleFont = false
 
@@ -610,15 +613,15 @@ private struct StampCardBody: View {
         VStack(spacing: 18) {
             HibiStamp(purchased: purchased, date: date,
                       size: 200 + 110 * expandFraction, stampToken: stampToken)
-            if expanded && !purchased {
+            if !purchased {
                 Text("Purchase Hibi Plus to receive your personalized seal.")
                     .font(.appSerif(size: 15, italic: true, simple: useSimpleFont))
                     .foregroundStyle(.secondary)
-                    .multilineTextAlignment(.center)
-                    .frame(maxWidth: 240)
+                    .lineLimit(1)
+                    .opacity(chromeFade)
             }
         }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .frame(maxWidth: .infinity)
         .padding(.horizontal, 16)
     }
 }
@@ -627,98 +630,80 @@ private struct StampCardBody: View {
 
 private struct FeatureCardBody: View {
     let purchased: Bool
-    let expanded: Bool
     let chromeFade: Double
     @Binding var ctaSuccess: Bool
     let onPurchase: () -> Void
     @AppStorage("useSimpleFont", store: AppGroup.defaults) private var useSimpleFont = false
 
     var body: some View {
-        VStack(spacing: 0) {
-            PlusHeader(deck: "Your support matters a lot.", showDeck: expanded)
-                .padding(.top, 14)
+        ZStack(alignment: .bottom) {
+            VStack(spacing: 0) {
+                PlusHeader(deck: "Your support matters a lot.", deckFade: chromeFade)
+                    .padding(.top, 14)
 
-            // hairline rule with center dot — expanded only
-            HStack(spacing: 8) {
-                Rectangle().frame(height: 0.5).foregroundStyle(.quaternary)
-                Text(verbatim: "·").foregroundStyle(.tertiary)
-                Rectangle().frame(height: 0.5).foregroundStyle(.quaternary)
-            }
-            .frame(width: 180, height: expanded ? nil : 0)
-            .opacity(chromeFade)
-            .padding(.top, expanded ? 16 : 0).padding(.bottom, expanded ? 12 : 0)
-
-            if !expanded { Spacer(minLength: 0) }
-
-            AppIconCarousel(size: 42)
-                .padding(.bottom, expanded ? 14 : 0)
-
-            if !expanded { Spacer(minLength: 0) }
-
-            // perks — expanded only
-            HStack(spacing: 12) {
-                perkTile {
-                    IconFan()
-                } rule: {
-                    Text("App icons")
-                } title: {
-                    Text("Dress Hibi up.")
+                HStack(spacing: 8) {
+                    Rectangle().frame(height: 0.5).foregroundStyle(.quaternary)
+                    Text(verbatim: "·").foregroundStyle(.tertiary)
+                    Rectangle().frame(height: 0.5).foregroundStyle(.quaternary)
                 }
-                perkTile {
-                    MiniPaperCard()
-                } rule: {
-                    Text("Early access")
-                } title: {
-                    Text("Try features first.")
-                }
-            }
-            .frame(height: expanded ? nil : 0)
-            .opacity(chromeFade)
-            .clipped()
-            .padding(.bottom, expanded ? 12 : 0)
-
-            EarlyAccessTile()
-                .frame(height: expanded ? nil : 0)
+                .frame(width: 180)
                 .opacity(chromeFade)
-                .clipped()
-                .padding(.bottom, expanded ? (purchased ? 10 : 14) : 0)
+                .padding(.top, 16 * chromeFade).padding(.bottom, 12 * chromeFade)
 
-            if purchased {
-                Text("Thank you for supporting Hibi.")
-                    .font(.appSerif(size: 11.5, italic: true, simple: useSimpleFont))
-                    .foregroundStyle(.tertiary)
-                    .multilineTextAlignment(.center)
-                    .frame(height: expanded ? nil : 0)
+                AppIconCarousel(size: 42)
+                    .padding(.bottom, 14 * chromeFade)
+
+                HStack(spacing: 12) {
+                    perkTile {
+                        IconFan()
+                    } rule: {
+                        Text("App icons")
+                    } title: {
+                        Text("Dress Hibi up.")
+                    }
+                    perkTile {
+                        MiniPaperCard()
+                    } rule: {
+                        Text("Early access")
+                    } title: {
+                        Text("Try features first.")
+                    }
+                }
+                .opacity(chromeFade)
+                .padding(.bottom, 12 * chromeFade)
+
+                EarlyAccessTile()
                     .opacity(chromeFade)
-                    .clipped()
-                    .padding(.bottom, expanded ? 30 : 0)
-            }
+                    .padding(.bottom, (purchased ? 10 : 14) * chromeFade)
 
-            if !expanded { Spacer(minLength: 0) }
-
-            if !purchased {
-                VStack(spacing: 8) {
-                    PlusCTA(showSuccess: $ctaSuccess, onPurchase: onPurchase)
-                    RestorePurchasesLink()
+                if purchased {
+                    Text("Thank you for supporting Hibi.")
+                        .font(.appSerif(size: 11.5, italic: true, simple: useSimpleFont))
+                        .foregroundStyle(.tertiary)
+                        .lineLimit(1)
+                        .opacity(chromeFade)
+                        .padding(.bottom, 30 * chromeFade)
                 }
-                .frame(height: expanded ? nil : 0)
-                .opacity(chromeFade)
-                .clipped()
-                .padding(.bottom, expanded ? 26 : 0)
-            }
 
-            // collapsed hint — sits at the bottom, above the perforation
+                if !purchased {
+                    VStack(spacing: 8) {
+                        PlusCTA(showSuccess: $ctaSuccess, onPurchase: onPurchase)
+                        RestorePurchasesLink()
+                    }
+                    .opacity(chromeFade)
+                    .padding(.bottom, 26 * chromeFade)
+                }
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.horizontal, 16)
+            .padding(.top, 8)
+
             Text("Tap to see what's inside.")
                 .font(.appSerif(size: 11.5, italic: true, simple: useSimpleFont))
                 .foregroundStyle(.tertiary)
-                .frame(height: expanded ? 0 : nil)
                 .opacity(1 - chromeFade)
-                .clipped()
-                .padding(.bottom, expanded ? 0 : 22)
+                .padding(.bottom, 22)
         }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .padding(.horizontal, 16)
-        .padding(.top, 8)
     }
 
     private func perkTile<V: View, R: View, T: View>(
@@ -733,10 +718,12 @@ private struct FeatureCardBody: View {
                     .font(.system(size: 9, weight: .semibold))
                     .tracking(1.6)
                     .foregroundStyle(.tertiary)
+                    .lineLimit(1)
                 title()
                     .font(.appSerif(size: 14, italic: true, simple: useSimpleFont))
                     .foregroundStyle(.primary)
                     .lineSpacing(-1)
+                    .lineLimit(1)
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -908,13 +895,28 @@ struct HibiPlusView: View {
             .overlay {
                 GeometryReader { proxy in
                     cardBody(index: index)
-                        .frame(width: proxy.size.width, height: proxy.size.height)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .frame(width: proxy.size.width, height: proxy.size.height, alignment: .top)
                         .allowsHitTesting(chromeAmount >= 1)
-                        .mask(alignment: .top) {
-                            VStack(spacing: 0) {
-                                Rectangle()
-                                    .frame(height: max(0, proxy.size.height - bottomContentProtection))
-                                Spacer(minLength: 0)
+                        .mask {
+                            HStack(spacing: 0) {
+                                LinearGradient(
+                                    stops: [.init(color: .clear, location: 0),
+                                            .init(color: .black, location: 1)],
+                                    startPoint: .leading, endPoint: .trailing
+                                )
+                                .frame(width: 16)
+                                VStack(spacing: 0) {
+                                    Rectangle()
+                                        .frame(height: max(0, proxy.size.height - bottomContentProtection))
+                                    Spacer(minLength: 0)
+                                }
+                                LinearGradient(
+                                    stops: [.init(color: .black, location: 0),
+                                            .init(color: .clear, location: 1)],
+                                    startPoint: .leading, endPoint: .trailing
+                                )
+                                .frame(width: 16)
                             }
                             .frame(width: proxy.size.width, height: proxy.size.height)
                         }
@@ -942,11 +944,10 @@ struct HibiPlusView: View {
     private func cardBody(index: Int) -> some View {
         if index == 0 {
             StampCardBody(purchased: isPlus, date: purchaseDate,
-                          expanded: expanded, expandFraction: 1 - collapseProgress,
-                          stampToken: stampToken)
+                          expandFraction: 1 - collapseProgress,
+                          chromeFade: chromeFade, stampToken: stampToken)
         } else {
-            FeatureCardBody(purchased: isPlus, expanded: expanded,
-                            chromeFade: chromeFade,
+            FeatureCardBody(purchased: isPlus, chromeFade: chromeFade,
                             ctaSuccess: $ctaSuccess, onPurchase: purchase)
         }
     }

--- a/Hibi/Views/SettingsView.swift
+++ b/Hibi/Views/SettingsView.swift
@@ -68,6 +68,7 @@ struct SettingsView: View {
             }
         }
         .background(Color(.systemGroupedBackground))
+        .ignoresSafeArea(edges: .bottom)
         .navigationTitle(Text(verbatim: "Hibi"))
         .navigationDestination(item: $settingsDestination) { destination in
             switch destination {

--- a/Hibi/Views/SettingsView.swift
+++ b/Hibi/Views/SettingsView.swift
@@ -12,11 +12,12 @@ struct SettingsView: View {
     @Environment(EventStore.self) private var eventStore
     @Environment(WeatherStore.self) private var weatherStore
     @State private var whatsNewVersion: NoteletPresentedVersion?
+    @State private var settingsDestination: SettingsDestination?
+    @State private var collapseProgress: CGFloat = 1
 
     enum Appearance: String, CaseIterable, Identifiable {
         case system, light, dark
         var id: String { rawValue }
-        /// Deferred-lookup resource so SwiftUI re-resolves when the locale changes.
         var labelResource: LocalizedStringResource {
             switch self {
             case .system: "System"
@@ -26,54 +27,112 @@ struct SettingsView: View {
         }
     }
 
+    enum SettingsDestination: String, Hashable, Identifiable {
+        case appearance, units, calendars
+        #if DEBUG
+        case stampNoise
+        #endif
+        var id: String { rawValue }
+    }
+
     var body: some View {
         VStack(spacing: 0) {
-            HibiPlusView()
+            HibiPlusView(collapseProgress: $collapseProgress)
                 .background(Color(.systemGroupedBackground))
                 .zIndex(1)
-            Form {
-                Section("General") {
-                NavigationLink {
-                    AppearanceSettingsView()
-                } label: {
-                    Label("Appearance", systemImage: "paintbrush")
-                }
-                NavigationLink {
-                    UnitsSettingsView()
-                } label: {
-                    Label("Units", systemImage: "ruler")
-                }
-                NavigationLink {
-                    CalendarSelectionView()
-                } label: {
-                    LabeledContent {
-                        Text(calendarSummary)
-                            .foregroundStyle(.secondary)
-                    } label: {
-                        Label("Calendars & Reminders", systemImage: "calendar")
+
+            HStack(spacing: 10) {
+                Rectangle().fill(.quaternary).frame(height: 0.5)
+                Capsule()
+                    .fill(.tertiary)
+                    .frame(width: 36, height: 5)
+                Rectangle().fill(.quaternary).frame(height: 0.5)
+            }
+            .padding(.vertical, 8)
+            .padding(.horizontal, 20)
+
+            HijackingScrollView(
+                progress: $collapseProgress,
+                collapseDistance: 200
+            ) {
+                settingsFormContent
+            }
+            .overlay(alignment: .top) {
+                LinearGradient(
+                    colors: [Color(.systemGroupedBackground),
+                             Color(.systemGroupedBackground).opacity(0)],
+                    startPoint: .top, endPoint: .bottom
+                )
+                .frame(height: 24)
+                .allowsHitTesting(false)
+            }
+        }
+        .background(Color(.systemGroupedBackground))
+        .navigationTitle(Text(verbatim: "Hibi"))
+        .navigationDestination(item: $settingsDestination) { destination in
+            switch destination {
+            case .appearance: AppearanceSettingsView()
+            case .units: UnitsSettingsView()
+            case .calendars: CalendarSelectionView()
+            #if DEBUG
+            case .stampNoise: StampNoiseDebugView()
+            #endif
+            }
+        }
+        .noteletSheet(
+            notes: WhatsNewContent.allNotes,
+            version: whatsNewVersion,
+            onDismiss: { whatsNewVersion = nil },
+            configuration: WhatsNewContent.configuration
+        )
+    }
+
+    // MARK: - Settings form content
+
+    private var settingsFormContent: some View {
+        VStack(spacing: 28) {
+            settingsSection("General") {
+                settingsNavRow("Appearance", systemImage: "paintbrush",
+                               destination: .appearance)
+                settingsDivider
+                settingsNavRow("Units", systemImage: "ruler",
+                               destination: .units)
+                settingsDivider
+                settingsRow(action: { settingsDestination = .calendars }) {
+                    HStack {
+                        LabeledContent {
+                            Text(calendarSummary)
+                                .foregroundStyle(.secondary)
+                        } label: {
+                            Label("Calendars & Reminders", systemImage: "calendar")
+                        }
+                        Spacer()
+                        Image(systemName: "chevron.right")
+                            .font(.system(size: 13, weight: .semibold))
+                            .foregroundStyle(.tertiary)
                     }
                 }
             }
 
             if hasMissingPermission {
-                Section("Permissions") {
-                    Button {
+                settingsSection("Permissions") {
+                    settingsRow(action: {
                         onReopenPermissions()
                         dismiss()
-                    } label: {
-                        LabeledContent {
+                    }) {
+                        HStack {
+                            Label("Review permissions",
+                                  systemImage: "exclamationmark.triangle")
+                            Spacer()
                             Image(systemName: "chevron.right")
                                 .font(.system(size: 13, weight: .semibold))
                                 .foregroundStyle(.tertiary)
-                        } label: {
-                            Label("Review permissions", systemImage: "exclamationmark.triangle")
                         }
                     }
-                    .tint(.primary)
                 }
             }
 
-            Section("About") {
+            settingsSection("About") {
                 Button {
                     whatsNewVersion = .v(WhatsNewContent.version)
                 } label: {
@@ -83,8 +142,14 @@ struct SettingsView: View {
                     } label: {
                         Text("What's New")
                     }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 12)
+                    .contentShape(Rectangle())
                 }
-                .tint(.primary)
+                .buttonStyle(.plain)
+
+                settingsDivider
 
                 Link(destination: URL(string: "https://apps.weichart.de")!) {
                     HStack(spacing: 12) {
@@ -92,7 +157,8 @@ struct SettingsView: View {
                             .resizable()
                             .aspectRatio(contentMode: .fit)
                             .frame(width: 28, height: 28)
-                            .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+                            .clipShape(RoundedRectangle(cornerRadius: 6,
+                                                         style: .continuous))
                         VStack(alignment: .leading, spacing: 1) {
                             Text("More Apps")
                                 .foregroundStyle(.primary)
@@ -105,11 +171,13 @@ struct SettingsView: View {
                             .font(.system(size: 13, weight: .semibold))
                             .foregroundStyle(.tertiary)
                     }
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 12)
                 }
             }
 
             #if DEBUG
-            Section("Debug") {
+            settingsSection("Debug") {
                 Toggle(isOn: Binding(
                     get: { eventStore.isDemoMode },
                     set: { eventStore.setDemoMode($0) }
@@ -117,33 +185,84 @@ struct SettingsView: View {
                     Label("Demo Mode", systemImage: "wand.and.stars")
                 }
                 .tint(.black)
+                .padding(.horizontal, 16)
+                .padding(.vertical, 12)
 
-                NavigationLink {
-                    StampNoiseDebugView()
-                } label: {
-                    Label("Stamp Noise", systemImage: "drop")
+                settingsDivider
+
+                settingsRow(action: { settingsDestination = .stampNoise }) {
+                    HStack {
+                        Label("Stamp Noise", systemImage: "drop")
+                        Spacer()
+                        Image(systemName: "chevron.right")
+                            .font(.system(size: 13, weight: .semibold))
+                            .foregroundStyle(.tertiary)
+                    }
                 }
             }
             #endif
+        }
+        .padding(.horizontal, 16)
+        .padding(.top, 28)
+        .padding(.bottom, 140)
+    }
+
+    // MARK: - Styled Form replacements
+
+    private func settingsSection(
+        _ title: LocalizedStringKey? = nil,
+        @ViewBuilder content: () -> some View
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 0) {
+            if let title {
+                Text(title)
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+                    .textCase(.uppercase)
+                    .padding(.horizontal, 4)
+                    .padding(.bottom, 8)
             }
-            .overlay(alignment: .top) {
-                LinearGradient(
-                    colors: [Color(.systemGroupedBackground),
-                             Color(.systemGroupedBackground).opacity(0)],
-                    startPoint: .top, endPoint: .bottom
-                )
-                .frame(height: 24)
-                .allowsHitTesting(false)
+            VStack(spacing: 0) { content() }
+                .background(Color(.secondarySystemGroupedBackground))
+                .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+        }
+    }
+
+    private func settingsRow<Label: View>(
+        action: @escaping () -> Void,
+        @ViewBuilder label: () -> Label
+    ) -> some View {
+        Button(action: action) {
+            label()
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, 16)
+                .padding(.vertical, 12)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+
+    private var settingsDivider: some View {
+        Divider().padding(.leading, 16)
+    }
+
+    private func settingsNavRow(
+        _ titleKey: LocalizedStringKey,
+        systemImage: String,
+        destination: SettingsDestination
+    ) -> some View {
+        settingsRow(action: { settingsDestination = destination }) {
+            HStack {
+                Label(titleKey, systemImage: systemImage)
+                Spacer()
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(.tertiary)
             }
         }
-        .navigationTitle(Text(verbatim: "Hibi"))
-        .noteletSheet(
-            notes: WhatsNewContent.allNotes,
-            version: whatsNewVersion,
-            onDismiss: { whatsNewVersion = nil },
-            configuration: WhatsNewContent.configuration
-        )
     }
+
+    // MARK: - Helpers
 
     private var calendarSummary: LocalizedStringResource {
         if eventStore.isDemoMode { return "Demo" }

--- a/docs/superpowers/plans/2026-05-26-scroll-collapse-unification.md
+++ b/docs/superpowers/plans/2026-05-26-scroll-collapse-unification.md
@@ -1,0 +1,694 @@
+# Scroll-Driven Paper Collapse — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make HibiPlusView in Settings collapsible/expandable by scrolling the settings list, matching DayView's scroll-driven collapse behavior exactly.
+
+**Architecture:** Replace SettingsView's `Form` with styled content inside `HijackingScrollView` (the proven UIKit scroll-intercept bridge from DayView). Convert HibiPlusView from boolean `expanded` to continuous `CGFloat` collapse progress. SettingsView owns the progress state; HijackingScrollView writes it per-frame during scroll; HibiPlusView reads it for visuals and writes it on tap-toggle.
+
+**Tech Stack:** SwiftUI, UIKit (HijackingScrollView UIViewRepresentable), EventKit/WeatherStore environments
+
+---
+
+## Why not keep the Form?
+
+SwiftUI `Form` is backed by `UICollectionView` internally. `HijackingScrollView` owns its own `UIScrollView` — you cannot nest a Form inside it without broken double-scrolling, and you cannot intercept Form's internal scroll without fragile UIKit introspection. Replacing the Form with manually-styled sections inside `HijackingScrollView` is the same proven pattern DayView uses for its schedule list. The settings list is small (≈7 rows across 4 sections), so the styling effort is minimal.
+
+`NavigationLink` requires a `NavigationStack` ancestor in the SwiftUI view tree. Content hosted inside `HijackingScrollView`'s `UIHostingController` is in a separate SwiftUI tree, so `NavigationLink` won't work there. The fix: use `Button` + `@State` destination enum inside the scroll content, with `.navigationDestination(item:)` on the outer `SettingsView` (which IS in the `NavigationStack` tree). State mutations cross the UIKit boundary because SwiftUI's state graph is global — the `@State` lives on `SettingsView`, and the Button action closure captures a reference to it.
+
+## Key design decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Progress convention | 0 = expanded, 1 = collapsed | Matches `HijackingScrollView` and DayView's `scheduleProgress` |
+| Default state | `collapseProgress = 1` (collapsed) | Settings paper starts compact so the list is immediately usable |
+| Content layout switching | Derived `expanded: Bool` from `collapseProgress < 0.5` | Card sub-views keep boolean show/hide; snaps during scroll (clipped by card shape), animates during snap/toggle |
+| Chrome fade | `max(0, 1 - collapseProgress * 1.25)` | Continuous opacity; content fully invisible at 80% collapsed (same overshoot as DayView) |
+| Collapse distance | Fixed 200pt | Compromise between stamp card (158pt visual change) and feature card (278pt). Both feel natural at ~0.8–1.4:1 ratio |
+| Card-swipe vs collapse | Orthogonal | Card tear gesture (vertical DragGesture on front card) is `highPriorityGesture`, fires before scroll. No conflict. |
+| Spring constant | `HijackingScrollView.snapSpring` (extracted) | Single source of truth for `.spring(response: 0.38, dampingFraction: 0.86)` used by DayView, HibiPlusView, and HijackingScrollView |
+
+## Transaction discipline (from learnings.md)
+
+Every per-frame write to `collapseProgress` MUST use:
+```swift
+var t = Transaction()
+t.disablesAnimations = true
+t.scrollContentOffsetAdjustmentBehavior = .disabled
+withTransaction(t) { binding.wrappedValue = newValue }
+```
+
+Snap/toggle writes use the same flags minus `disablesAnimations`, plus a spring animation:
+```swift
+var t = Transaction()
+t.animation = HijackingScrollView<EmptyView>.snapSpring
+t.scrollContentOffsetAdjustmentBehavior = .disabled
+withTransaction(t) { binding.wrappedValue = target }
+```
+
+`HijackingScrollView` already does this internally. The tap-toggle in `HibiPlusView` must follow the same pattern.
+
+---
+
+### Task 1: Extract shared collapse spring constant
+
+**Files:**
+- Modify: `Hibi/Views/Components/HijackingScrollView.swift`
+
+- [ ] **Step 1: Add static `snapSpring` to HijackingScrollView**
+
+At the top of the `HijackingScrollView` struct (after the properties, before `makeCoordinator`), add:
+
+```swift
+static var snapSpring: Animation {
+    .spring(response: 0.38, dampingFraction: 0.86)
+}
+```
+
+This must be a static computed property (not stored) because `HijackingScrollView` is generic — stored static properties aren't allowed on generic types.
+
+- [ ] **Step 2: Use `snapSpring` in the Coordinator's snap closure**
+
+In `makeCoordinator()` and `updateUIView(_:context:)`, replace the inline spring:
+
+```swift
+// OLD:
+t.animation = .spring(response: 0.38, dampingFraction: 0.86)
+// NEW:
+t.animation = HijackingScrollView.snapSpring
+```
+
+There are two occurrences in `makeCoordinator` (line 38) and two in `updateUIView` (line 89).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Hibi/Views/Components/HijackingScrollView.swift
+git commit -m "refactor: extract shared snapSpring constant on HijackingScrollView
+
+Both DayView and the upcoming SettingsView scroll-collapse
+use the same spring parameters. Single source of truth.
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Convert HibiPlusView from Bool to CGFloat progress
+
+**Files:**
+- Modify: `Hibi/Views/HibiPlusView.swift`
+
+- [ ] **Step 1: Change the HibiPlusView interface**
+
+Replace the internal `expanded` state with a binding and derived Bool. In `struct HibiPlusView: View` (line 745):
+
+```swift
+// REMOVE these lines:
+@State private var expanded = false
+
+// ADD these lines (at the top of the struct, before other @State properties):
+/// 0 = expanded (paper tall), 1 = collapsed (paper compact).
+/// Owned by the parent (SettingsView); driven by HijackingScrollView
+/// per-frame during scroll, and by tap-toggle on the front card.
+@Binding var collapseProgress: CGFloat
+
+/// Derived boolean for card sub-views that need binary show/hide.
+/// Snaps at the midpoint — during scroll the snap is unanimated
+/// (clipped by the card shape); during snap/toggle it animates
+/// with the collapse spring.
+private var expanded: Bool { collapseProgress < 0.5 }
+```
+
+- [ ] **Step 2: Add a continuous chromeFade computed property**
+
+Below the `expanded` computed property, add:
+
+```swift
+/// Continuous 0…1 fade for expanded-only chrome. Reaches fully
+/// invisible at 80% collapsed (overshoot matches DayView).
+private var chromeFade: Double {
+    Double(max(0, 1 - collapseProgress * 1.25))
+}
+```
+
+- [ ] **Step 3: Update card sizing to continuous interpolation**
+
+In the `body` computed property (line 770), replace the boolean-gated sizes with lerp:
+
+```swift
+// OLD:
+let frontW = expanded ? w - 32 : HPLayout.collapsed.width
+let frontH = expanded ? expandedHeight(for: frontIndex) : HPLayout.collapsed.height
+let backW = expanded ? w - 32 : HPLayout.collapsed.width
+let backH = expanded ? expandedHeight(for: backIndex) : HPLayout.collapsed.height
+
+// NEW:
+let ef = 1 - collapseProgress // expand fraction: 0 = collapsed, 1 = expanded
+let frontW = HPLayout.collapsed.width + (w - 32 - HPLayout.collapsed.width) * ef
+let frontH = HPLayout.collapsed.height + (expandedHeight(for: frontIndex) - HPLayout.collapsed.height) * ef
+let backW = HPLayout.collapsed.width + (w - 32 - HPLayout.collapsed.width) * ef
+let backH = HPLayout.collapsed.height + (expandedHeight(for: backIndex) - HPLayout.collapsed.height) * ef
+```
+
+- [ ] **Step 4: Update totalHeight to use continuous progress**
+
+Replace the `totalHeight` computed property (line 792):
+
+```swift
+// OLD:
+private var totalHeight: CGFloat {
+    let frontH = expanded ? expandedHeight(for: frontIndex) : HPLayout.collapsed.height
+    let backH = expanded ? expandedHeight(for: backIndex) : HPLayout.collapsed.height
+    let h = lerp(frontH, backH, cardShift)
+    return h + 14 + HPLayout.hintHeight
+}
+
+// NEW:
+private var totalHeight: CGFloat {
+    let ef = 1 - collapseProgress
+    let frontH = HPLayout.collapsed.height + (expandedHeight(for: frontIndex) - HPLayout.collapsed.height) * ef
+    let backH = HPLayout.collapsed.height + (expandedHeight(for: backIndex) - HPLayout.collapsed.height) * ef
+    let h = lerp(frontH, backH, cardShift)
+    let hintH = HPLayout.hintHeight * ef
+    return h + 14 + hintH
+}
+```
+
+- [ ] **Step 5: Update hint text to fade with progress**
+
+Replace the `hint` computed property (line 935):
+
+```swift
+// OLD:
+private var hint: some View {
+    Text("Pull to tear · ↑ Next · ↓ Prev")
+        .font(.appSerif(size: 13, italic: true, simple: useSimpleFont))
+        .foregroundStyle(.tertiary)
+        .frame(maxWidth: .infinity)
+}
+
+// NEW:
+private var hint: some View {
+    let ef = 1 - collapseProgress
+    return Text("Pull to tear · ↑ Next · ↓ Prev")
+        .font(.appSerif(size: 13, italic: true, simple: useSimpleFont))
+        .foregroundStyle(.tertiary)
+        .frame(maxWidth: .infinity)
+        .frame(height: HPLayout.hintHeight * ef)
+        .opacity(chromeFade)
+        .clipped()
+}
+```
+
+- [ ] **Step 6: Update toggleExpand to use transaction-based animation on the binding**
+
+Replace the `toggleExpand()` function (line 959):
+
+```swift
+// OLD:
+private func toggleExpand() {
+    guard !isAnimating else { return }
+    withAnimation(HPLayout.collapseSpring) { expanded.toggle() }
+}
+
+// NEW:
+private func toggleExpand() {
+    guard !isAnimating else { return }
+    let target: CGFloat = collapseProgress >= 0.5 ? 0 : 1
+    var t = Transaction()
+    t.animation = HijackingScrollView<EmptyView>.snapSpring
+    t.scrollContentOffsetAdjustmentBehavior = .disabled
+    withTransaction(t) { collapseProgress = target }
+}
+```
+
+- [ ] **Step 7: Remove the `.animation(_, value: expanded)` modifier**
+
+In the body (line 788), remove:
+
+```swift
+// REMOVE:
+.animation(HPLayout.collapseSpring, value: expanded)
+```
+
+Keep `.animation(HPLayout.collapseSpring, value: isPlus)` — that drives the purchase flow and is orthogonal.
+
+- [ ] **Step 8: Update FeatureCardBody to accept continuous chromeFade**
+
+In `FeatureCardBody` (line 616), change the `expanded` property and derived `chromeFade`:
+
+```swift
+// OLD:
+let expanded: Bool
+// ...
+private var chromeFade: Double { expanded ? 1 : 0 }
+
+// NEW:
+let expanded: Bool
+let chromeFade: Double
+```
+
+Remove the `private var chromeFade` computed property entirely (line 623). The `chromeFade` is now passed in from HibiPlusView.
+
+- [ ] **Step 9: Update StampCardBody stamp size to continuous interpolation**
+
+In `StampCardBody` (line 590), change the stamp size from boolean to continuous:
+
+```swift
+// OLD:
+let expanded: Bool
+// ...
+HibiStamp(purchased: purchased, date: date,
+          size: expanded ? 310 : 200, stampToken: stampToken)
+
+// NEW:
+let expanded: Bool
+let expandFraction: CGFloat
+// ...
+HibiStamp(purchased: purchased, date: date,
+          size: 200 + 110 * expandFraction, stampToken: stampToken)
+```
+
+- [ ] **Step 10: Update cardBody to pass the new parameters**
+
+In `cardBody(index:)` (line 924), update the calls:
+
+```swift
+// OLD:
+if index == 0 {
+    StampCardBody(purchased: isPlus, date: purchaseDate,
+                  expanded: expanded, stampToken: stampToken)
+} else {
+    FeatureCardBody(purchased: isPlus, expanded: expanded,
+                    ctaSuccess: $ctaSuccess, onPurchase: purchase)
+}
+
+// NEW:
+if index == 0 {
+    StampCardBody(purchased: isPlus, date: purchaseDate,
+                  expanded: expanded, expandFraction: 1 - collapseProgress,
+                  stampToken: stampToken)
+} else {
+    FeatureCardBody(purchased: isPlus, expanded: expanded,
+                    chromeFade: chromeFade,
+                    ctaSuccess: $ctaSuccess, onPurchase: purchase)
+}
+```
+
+- [ ] **Step 11: Build to verify compilation**
+
+```bash
+xcodebuild -project Hibi.xcodeproj -scheme Hibi \
+  -destination 'generic/platform=iOS Simulator' build 2>&1 | tail -5
+```
+
+Expected: BUILD SUCCEEDED. There will be a build error in SettingsView because `HibiPlusView()` is called without the new binding — that's fixed in Task 3.
+
+To temporarily unblock the build, add a default value to the binding parameter:
+
+In HibiPlusView, temporarily change:
+```swift
+// Add a convenience init that defaults to collapsed:
+init(collapseProgress: Binding<CGFloat> = .constant(1)) {
+    self._collapseProgress = collapseProgress
+}
+```
+
+This will be removed in Task 3 when SettingsView passes the real binding.
+
+- [ ] **Step 12: Commit**
+
+```bash
+git add Hibi/Views/HibiPlusView.swift
+git commit -m "refactor: convert HibiPlusView from Bool expand to CGFloat progress
+
+Card sizing now interpolates continuously with collapseProgress
+(0 = expanded, 1 = collapsed). Sub-views receive continuous
+chromeFade for smooth opacity transitions and a derived expanded
+Bool for binary content switching. Tap-toggle uses the same
+transaction discipline as HijackingScrollView.
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Replace Form with scroll-driven content in SettingsView
+
+**Files:**
+- Modify: `Hibi/Views/SettingsView.swift`
+
+- [ ] **Step 1: Add state variables and destination enum**
+
+At the top of `SettingsView`, add:
+
+```swift
+/// Navigation target for settings sub-pages. Buttons inside
+/// HijackingScrollView set this; .navigationDestination on the
+/// outer VStack handles the push (the hosting controller's SwiftUI
+/// tree can't see the NavigationStack, but state mutations cross
+/// the UIKit boundary).
+@State private var settingsDestination: SettingsDestination?
+
+/// 0 = paper expanded, 1 = paper collapsed. Shared between
+/// HibiPlusView (reads + tap-writes) and HijackingScrollView
+/// (scroll-writes).
+@State private var collapseProgress: CGFloat = 1
+
+enum SettingsDestination: String, Hashable, Identifiable {
+    case appearance, units, calendars
+    var id: String { rawValue }
+}
+```
+
+- [ ] **Step 2: Create private styled-section helpers**
+
+Add these private helpers at the bottom of `SettingsView` (before the closing brace), or as a file-private extension:
+
+```swift
+// MARK: - Styled Form replacements
+
+private func settingsSection(
+    _ title: LocalizedStringKey? = nil,
+    @ViewBuilder content: () -> some View
+) -> some View {
+    VStack(alignment: .leading, spacing: 0) {
+        if let title {
+            Text(title)
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+                .textCase(.uppercase)
+                .padding(.horizontal, 4)
+                .padding(.bottom, 8)
+        }
+        VStack(spacing: 0) { content() }
+            .background(Color(.secondarySystemGroupedBackground))
+            .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+    }
+}
+
+private func settingsRow<Label: View>(
+    action: @escaping () -> Void,
+    @ViewBuilder label: () -> Label
+) -> some View {
+    Button(action: action) {
+        label()
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 16)
+            .padding(.vertical, 12)
+            .contentShape(Rectangle())
+    }
+    .buttonStyle(.plain)
+}
+
+private var settingsDivider: some View {
+    Divider().padding(.leading, 16)
+}
+
+private func settingsNavRow(
+    _ titleKey: LocalizedStringKey,
+    systemImage: String,
+    destination: SettingsDestination
+) -> some View {
+    settingsRow(action: { settingsDestination = destination }) {
+        HStack {
+            Label(titleKey, systemImage: systemImage)
+            Spacer()
+            Image(systemName: "chevron.right")
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(.tertiary)
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Create the settings form content**
+
+Add a private computed property that builds all the settings rows:
+
+```swift
+private var settingsFormContent: some View {
+    VStack(spacing: 28) {
+        settingsSection("General") {
+            settingsNavRow("Appearance", systemImage: "paintbrush",
+                           destination: .appearance)
+            settingsDivider
+            settingsNavRow("Units", systemImage: "ruler",
+                           destination: .units)
+            settingsDivider
+            settingsRow(action: { settingsDestination = .calendars }) {
+                HStack {
+                    LabeledContent {
+                        Text(calendarSummary)
+                            .foregroundStyle(.secondary)
+                    } label: {
+                        Label("Calendars & Reminders", systemImage: "calendar")
+                    }
+                    Spacer()
+                    Image(systemName: "chevron.right")
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundStyle(.tertiary)
+                }
+            }
+        }
+
+        if hasMissingPermission {
+            settingsSection("Permissions") {
+                settingsRow(action: {
+                    onReopenPermissions()
+                    dismiss()
+                }) {
+                    HStack {
+                        Label("Review permissions",
+                              systemImage: "exclamationmark.triangle")
+                        Spacer()
+                        Image(systemName: "chevron.right")
+                            .font(.system(size: 13, weight: .semibold))
+                            .foregroundStyle(.tertiary)
+                    }
+                }
+            }
+        }
+
+        settingsSection("About") {
+            Button {
+                whatsNewVersion = .v(WhatsNewContent.version)
+            } label: {
+                LabeledContent {
+                    Text(Self.versionLabel)
+                        .foregroundStyle(.secondary)
+                } label: {
+                    Text("What's New")
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, 16)
+                .padding(.vertical, 12)
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+
+            settingsDivider
+
+            Link(destination: URL(string: "https://apps.weichart.de")!) {
+                HStack(spacing: 12) {
+                    Image("WeichartApps")
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .frame(width: 28, height: 28)
+                        .clipShape(RoundedRectangle(cornerRadius: 6,
+                                                     style: .continuous))
+                    VStack(alignment: .leading, spacing: 1) {
+                        Text("More Apps")
+                            .foregroundStyle(.primary)
+                        Text(verbatim: "apps.weichart.de")
+                            .font(.footnote)
+                            .foregroundStyle(.secondary)
+                    }
+                    Spacer()
+                    Image(systemName: "arrow.up.right")
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundStyle(.tertiary)
+                }
+                .padding(.horizontal, 16)
+                .padding(.vertical, 12)
+            }
+        }
+
+        #if DEBUG
+        settingsSection("Debug") {
+            Toggle(isOn: Binding(
+                get: { eventStore.isDemoMode },
+                set: { eventStore.setDemoMode($0) }
+            )) {
+                Label("Demo Mode", systemImage: "wand.and.stars")
+            }
+            .tint(.black)
+            .padding(.horizontal, 16)
+            .padding(.vertical, 12)
+        }
+        #endif
+    }
+    .padding(.horizontal, 16)
+    .padding(.top, 28)
+    .padding(.bottom, 140)
+}
+```
+
+- [ ] **Step 4: Replace the body with HijackingScrollView layout**
+
+Replace the entire `body` computed property:
+
+```swift
+var body: some View {
+    VStack(spacing: 0) {
+        HibiPlusView(collapseProgress: $collapseProgress)
+            .background(Color(.systemGroupedBackground))
+            .zIndex(1)
+
+        // Separator handle — visual cue matching DayView's
+        // schedule separator. Not independently draggable;
+        // collapse is driven by the HijackingScrollView below.
+        HStack(spacing: 10) {
+            Rectangle().fill(.quaternary).frame(height: 0.5)
+            Capsule()
+                .fill(.tertiary)
+                .frame(width: 36, height: 5)
+            Rectangle().fill(.quaternary).frame(height: 0.5)
+        }
+        .padding(.vertical, 8)
+        .padding(.horizontal, 20)
+
+        HijackingScrollView(
+            progress: $collapseProgress,
+            collapseDistance: 200
+        ) {
+            settingsFormContent
+        }
+        .overlay(alignment: .top) {
+            LinearGradient(
+                colors: [Color(.systemGroupedBackground),
+                         Color(.systemGroupedBackground).opacity(0)],
+                startPoint: .top, endPoint: .bottom
+            )
+            .frame(height: 24)
+            .allowsHitTesting(false)
+        }
+    }
+    .background(Color(.systemGroupedBackground))
+    .navigationTitle(Text(verbatim: "Hibi"))
+    .navigationDestination(item: $settingsDestination) { destination in
+        switch destination {
+        case .appearance: AppearanceSettingsView()
+        case .units: UnitsSettingsView()
+        case .calendars: CalendarSelectionView()
+        }
+    }
+    .noteletSheet(
+        notes: WhatsNewContent.allNotes,
+        version: whatsNewVersion,
+        onDismiss: { whatsNewVersion = nil },
+        configuration: WhatsNewContent.configuration
+    )
+}
+```
+
+- [ ] **Step 5: Remove the temporary default binding from HibiPlusView**
+
+In `HibiPlusView.swift`, remove the convenience init added in Task 2 Step 11. The binding is now always provided by SettingsView.
+
+If HibiPlusView doesn't have a custom init (just uses memberwise), the `@Binding var collapseProgress: CGFloat` requires callers to pass it explicitly — which SettingsView now does.
+
+- [ ] **Step 6: Make AppearanceSettingsView and UnitsSettingsView non-private**
+
+Currently both are `private struct`. Since `.navigationDestination` in `SettingsView` now references them directly (they were previously only referenced via `NavigationLink` in the same file scope), they need to be accessible. Since they're in the same file as `SettingsView`, `private` already works. Verify this compiles — if `navigationDestination`'s closure can see private types in the same file, no change is needed. If not, change them to `fileprivate` or internal.
+
+- [ ] **Step 7: Build to verify compilation**
+
+```bash
+xcodebuild -project Hibi.xcodeproj -scheme Hibi \
+  -destination 'generic/platform=iOS Simulator' build 2>&1 | tail -5
+```
+
+Expected: BUILD SUCCEEDED.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add Hibi/Views/SettingsView.swift Hibi/Views/HibiPlusView.swift
+git commit -m "feat: scroll-driven paper collapse in Settings
+
+Replace Form with styled sections inside HijackingScrollView.
+Scrolling the settings list up collapses the paper stack;
+pulling down at the top expands it. Same magnetic snap and
+transaction discipline as DayView.
+
+Button-based navigation with .navigationDestination replaces
+NavigationLink (required because HijackingScrollView hosts
+content in a UIHostingController, outside the NavigationStack
+view tree).
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Build verification and manual test checklist
+
+- [ ] **Step 1: Full clean build**
+
+```bash
+xcodebuild -project Hibi.xcodeproj -scheme Hibi \
+  -destination 'generic/platform=iOS Simulator' \
+  clean build 2>&1 | tail -10
+```
+
+Expected: BUILD SUCCEEDED with no warnings in modified files.
+
+- [ ] **Step 2: Document what to test on device**
+
+The following must be verified on a physical device (no simulator per CLAUDE.md):
+
+**Scroll-driven collapse:**
+- [ ] Open Settings → paper starts collapsed (compact)
+- [ ] Scroll the settings list up → paper collapses smoothly (if not already)
+- [ ] Pull down at the top of the settings list → paper expands smoothly
+- [ ] Quick flick up → paper snaps to collapsed with spring
+- [ ] Quick flick down at top → paper snaps to expanded with spring
+- [ ] Slow drag and release at ~50% → snaps to nearest end
+- [ ] Velocity-biased snap: fast flick from <50% still commits
+
+**Tap-to-toggle:**
+- [ ] Tap the paper stack → toggles between expanded and collapsed with spring animation
+- [ ] Tap during scroll-driven mid-collapse → snaps correctly
+
+**Card swipe (tear):**
+- [ ] Pull card up/down past threshold → card tears, next card rises
+- [ ] Card swipe works identically in both expanded and collapsed states
+- [ ] No conflict between card swipe and scroll-driven collapse
+
+**Navigation:**
+- [ ] Tap "Appearance" row → pushes AppearanceSettingsView
+- [ ] Tap "Units" row → pushes UnitsSettingsView
+- [ ] Tap "Calendars & Reminders" row → pushes CalendarSelectionView
+- [ ] Back button works from all sub-pages
+- [ ] "Review permissions" button works (if permissions section visible)
+- [ ] "What's New" button opens the Notelet sheet
+- [ ] "More Apps" link opens Safari
+
+**Visual polish:**
+- [ ] Section styling approximates Form grouped-inset look (rounded corners, correct background colors)
+- [ ] Gradient overlay at top of scroll content present
+- [ ] Separator handle (capsule) visible between paper and list
+- [ ] No flicker during slow drag (transaction discipline working)
+- [ ] Dark mode: correct colors, high-contrast paper stack
+- [ ] Card shadows render correctly over the settings list
+
+**Performance:**
+- [ ] No jank during scroll-driven collapse (60fps)
+- [ ] No memory growth from repeated expand/collapse cycles
+
+**DayView regression:**
+- [ ] DayView schedule collapse still works identically
+- [ ] DayView tap-to-toggle still works
+- [ ] DayView HijackingScrollView behavior unchanged


### PR DESCRIPTION
## Summary

- **Scroll-driven collapse**: The HibiPlus paper stack in Settings now collapses/expands by scrolling the settings list, matching DayView's behavior. Uses `HijackingScrollView` to intercept scroll deltas and drive a shared `collapseProgress` (0…1) binding.
- **Continuous transitions**: Replaced binary `expanded` Bool gating (`frame(height: expanded ? nil : 0)`, conditional Spacers) with `chromeFade`-multiplied padding and opacity, so card content scales smoothly during collapse instead of popping in at a threshold.
- **Overflow handling**: Added `.lineLimit(1)` to all card text and horizontal fade masks on card edges so text overflows gracefully rather than wrapping and causing layout reflows.
- **Safe area fix**: Extended SettingsView layout past the bottom safe area so content isn't cut off at the home indicator.
- **Shared spring**: Extracted `HijackingScrollView.snapSpring` constant reused by both DayView and Settings collapse snapping.
- **Settings Form → styled sections**: Replaced `Form` with custom styled sections inside `HijackingScrollView`, using `Button` + `.navigationDestination(item:)` for navigation (required since content is inside a UIHostingController subtree where NavigationLink doesn't work).

## Test plan

- [ ] Open Settings, scroll list up — paper stack collapses smoothly
- [ ] Scroll list back down at top — paper stack re-expands
- [ ] Verify no text wrapping during collapse transition — text overflows with fade
- [ ] Verify settings list scrolls to the bottom (past home indicator area)
- [ ] Tap paper stack — toggle expand/collapse still works
- [ ] Drag paper cards — tear/flip still works
- [ ] Navigate to Appearance, Units, Calendars sub-pages
- [ ] Verify "What's New" and "More Apps" links work
- [ ] Test in dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)