### PR TITLE
Implement Hibi Plus in-app purchase with StoreKit 2

### DIFF
--- a/Hibi.storekit
+++ b/Hibi.storekit
@@ -1,0 +1,38 @@
+{
+  "identifier" : "B3F1A4C2-0E7D-4F2A-9C61-2A8F5D4E1B90",
+  "nonRenewingSubscriptions" : [
+
+  ],
+  "products" : [
+    {
+      "displayPrice" : "4.99",
+      "familyShareable" : false,
+      "internalID" : "1D9C7E55-3A42-4B8E-A0F6-7C2B9E14D3A1",
+      "localizations" : [
+        {
+          "description" : "Unlock all app icons, your personalized stamp, and home-screen widgets. One-time purchase.",
+          "displayName" : "Hibi Plus",
+          "locale" : "en_US"
+        }
+      ],
+      "productID" : "com.weichart.hibi.plus",
+      "referenceName" : "Hibi Plus",
+      "type" : "NonConsumable"
+    }
+  ],
+  "settings" : {
+    "_failTransactionsEnabled" : false,
+    "_locale" : "en_US",
+    "_storefront" : "USA",
+    "_storeKitErrors" : [
+
+    ]
+  },
+  "subscriptionGroups" : [
+
+  ],
+  "version" : {
+    "major" : 3,
+    "minor" : 0
+  }
+}

--- a/Hibi.xcodeproj/project.pbxproj
+++ b/Hibi.xcodeproj/project.pbxproj
@@ -23,6 +23,13 @@
 			remoteGlobalIDString = 4B1507002FBEA5BF00F49AFD;
 			remoteInfo = HibiWidgetsExtension;
 		};
+		4B20000B2FC2000000F49AFD /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 4B802FC52F8F5453008F00F4 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 4B802FCC2F8F5453008F00F4;
+			remoteInfo = Hibi;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -41,10 +48,12 @@
 
 /* Begin PBXFileReference section */
 		4B0451052F96B000009EA06E /* Config.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = "<group>"; };
+		4B20000C2FC2000000F49AFD /* Hibi.storekit */ = {isa = PBXFileReference; lastKnownFileType = text; path = Hibi.storekit; sourceTree = "<group>"; };
 		4B1507012FBEA5BF00F49AFD /* HibiWidgetsExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = HibiWidgetsExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		4B1507032FBEA5BF00F49AFD /* WidgetKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WidgetKit.framework; path = System/Library/Frameworks/WidgetKit.framework; sourceTree = SDKROOT; };
 		4B1507052FBEA5BF00F49AFD /* SwiftUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftUI.framework; path = System/Library/Frameworks/SwiftUI.framework; sourceTree = SDKROOT; };
 		4B802FCD2F8F5453008F00F4 /* Hibi.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Hibi.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		4B2000022FC2000000F49AFD /* HibiTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = HibiTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -65,6 +74,7 @@
 				Localizable.xcstrings,
 				Models/AppGroup.swift,
 				Models/CalendarEvent.swift,
+				Models/PlusEntitlement.swift,
 				Models/Preferences.swift,
 				Models/SampleData.swift,
 				Models/WidgetEventsSnapshot.swift,
@@ -105,6 +115,11 @@
 			path = Hibi;
 			sourceTree = "<group>";
 		};
+		4B2000012FC2000000F49AFD /* HibiTests */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = HibiTests;
+			sourceTree = "<group>";
+		};
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -127,6 +142,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		4B2000052FC2000000F49AFD /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -143,8 +165,10 @@
 			isa = PBXGroup;
 			children = (
 				4B0451052F96B000009EA06E /* Config.xcconfig */,
+				4B20000C2FC2000000F49AFD /* Hibi.storekit */,
 				4B802FCF2F8F5453008F00F4 /* Hibi */,
 				4B1507072FBEA5BF00F49AFD /* HibiWidgets */,
+				4B2000012FC2000000F49AFD /* HibiTests */,
 				4B1507022FBEA5BF00F49AFD /* Frameworks */,
 				4B802FCE2F8F5453008F00F4 /* Products */,
 			);
@@ -155,6 +179,7 @@
 			children = (
 				4B802FCD2F8F5453008F00F4 /* Hibi.app */,
 				4B1507012FBEA5BF00F49AFD /* HibiWidgetsExtension.appex */,
+				4B2000022FC2000000F49AFD /* HibiTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -211,6 +236,29 @@
 			productReference = 4B802FCD2F8F5453008F00F4 /* Hibi.app */;
 			productType = "com.apple.product-type.application";
 		};
+		4B2000032FC2000000F49AFD /* HibiTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 4B2000092FC2000000F49AFD /* Build configuration list for PBXNativeTarget "HibiTests" */;
+			buildPhases = (
+				4B2000042FC2000000F49AFD /* Sources */,
+				4B2000052FC2000000F49AFD /* Frameworks */,
+				4B2000062FC2000000F49AFD /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				4B20000A2FC2000000F49AFD /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				4B2000012FC2000000F49AFD /* HibiTests */,
+			);
+			name = HibiTests;
+			packageProductDependencies = (
+			);
+			productName = HibiTests;
+			productReference = 4B2000022FC2000000F49AFD /* HibiTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -226,6 +274,10 @@
 					};
 					4B802FCC2F8F5453008F00F4 = {
 						CreatedOnToolsVersion = 26.4;
+					};
+					4B2000032FC2000000F49AFD = {
+						CreatedOnToolsVersion = 26.5;
+						TestTargetID = 4B802FCC2F8F5453008F00F4;
 					};
 				};
 			};
@@ -259,6 +311,7 @@
 			targets = (
 				4B802FCC2F8F5453008F00F4 /* Hibi */,
 				4B1507002FBEA5BF00F49AFD /* HibiWidgetsExtension */,
+				4B2000032FC2000000F49AFD /* HibiTests */,
 			);
 		};
 /* End PBXProject section */
@@ -272,6 +325,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		4B802FCB2F8F5453008F00F4 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		4B2000062FC2000000F49AFD /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -295,6 +355,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		4B2000042FC2000000F49AFD /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -302,6 +369,11 @@
 			isa = PBXTargetDependency;
 			target = 4B1507002FBEA5BF00F49AFD /* HibiWidgetsExtension */;
 			targetProxy = 4B15070F2FBEA5C200F49AFD /* PBXContainerItemProxy */;
+		};
+		4B20000A2FC2000000F49AFD /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 4B802FCC2F8F5453008F00F4 /* Hibi */;
+			targetProxy = 4B20000B2FC2000000F49AFD /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -561,6 +633,50 @@
 			};
 			name = Release;
 		};
+		4B2000072FC2000000F49AFD /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 22;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
+				MARKETING_VERSION = 1.10;
+				PRODUCT_BUNDLE_IDENTIFIER = com.weichart.hibi.HibiTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Hibi.app/Hibi";
+			};
+			name = Debug;
+		};
+		4B2000082FC2000000F49AFD /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 22;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
+				MARKETING_VERSION = 1.10;
+				PRODUCT_BUNDLE_IDENTIFIER = com.weichart.hibi.HibiTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Hibi.app/Hibi";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -587,6 +703,15 @@
 			buildConfigurations = (
 				4B802FD92F8F5454008F00F4 /* Debug */,
 				4B802FDA2F8F5454008F00F4 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		4B2000092FC2000000F49AFD /* Build configuration list for PBXNativeTarget "HibiTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				4B2000072FC2000000F49AFD /* Debug */,
+				4B2000082FC2000000F49AFD /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Hibi.xcodeproj/xcshareddata/xcschemes/Hibi.xcscheme
+++ b/Hibi.xcodeproj/xcshareddata/xcschemes/Hibi.xcscheme
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2650"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "4B802FCC2F8F5453008F00F4"
+               BuildableName = "Hibi.app"
+               BlueprintName = "Hibi"
+               ReferencedContainer = "container:Hibi.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <TestPlans>
+      </TestPlans>
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "4B2000032FC2000000F49AFD"
+               BuildableName = "HibiTests.xctest"
+               BlueprintName = "HibiTests"
+               ReferencedContainer = "container:Hibi.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4B802FCC2F8F5453008F00F4"
+            BuildableName = "Hibi.app"
+            BlueprintName = "Hibi"
+            ReferencedContainer = "container:Hibi.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <StoreKitConfigurationFileReference
+         identifier = "../Hibi.storekit">
+      </StoreKitConfigurationFileReference>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4B802FCC2F8F5453008F00F4"
+            BuildableName = "Hibi.app"
+            BlueprintName = "Hibi"
+            ReferencedContainer = "container:Hibi.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Hibi/ContentView.swift
+++ b/Hibi/ContentView.swift
@@ -37,6 +37,7 @@ struct ContentView: View {
     @State private var weatherStore = WeatherStore()
     @State private var clock = Clock()
     @State private var appIconManager = AppIconManager()
+    @State private var plusStore = PlusStore()
     @State private var editorMode: EventEditorSheet.Mode?
     @State private var showOnboarding = false
     @State private var needsOnboarding = false
@@ -240,6 +241,7 @@ struct ContentView: View {
         .environment(weatherStore)
         .environment(clock)
         .environment(appIconManager)
+        .environment(plusStore)
         .onOpenURL { url in
             guard url.scheme == "hibi" else { return }
             switch url.host {
@@ -299,6 +301,8 @@ struct ContentView: View {
             )
         }
         .task {
+            plusStore.start()
+            appIconManager.isPlus = plusStore.isPlus
             eventStore.ensureLoaded(year: displayedYear, month: displayedMonth)
             weatherStore.refresh()
             if !eventStore.isDemoMode {
@@ -331,6 +335,9 @@ struct ContentView: View {
             if newValue {
                 eventStore.ensureLoaded(year: displayedYear, month: displayedMonth)
             }
+        }
+        .onChange(of: plusStore.isPlus) { _, newValue in
+            appIconManager.isPlus = newValue
         }
         .onChange(of: scenePhase) { _, phase in
             if phase == .active {

--- a/Hibi/Localizable.xcstrings
+++ b/Hibi/Localizable.xcstrings
@@ -1431,74 +1431,191 @@
         }
       }
     },
-    "Buy Hibi Plus, $4.99 one-time": {
+    "Buy Hibi Plus, %@ one-time": {
       "extractionState": "manual",
       "localizations": {
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Hibi Plus kaufen, 4,99 $ einmalig"
+            "value": "Hibi Plus kaufen, %@ einmalig"
           }
         },
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Buy Hibi Plus, $4.99 one-time"
+            "value": "Buy Hibi Plus, %@ one-time"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Comprar Hibi Plus, $4.99 pago único"
+            "value": "Comprar Hibi Plus, %@ pago único"
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Acquista Hibi Plus, $4,99 una tantum"
+            "value": "Acquista Hibi Plus, %@ una tantum"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Hibi Plusを購入する、$4.99 買い切り"
+            "value": "Hibi Plusを購入する、%@ 買い切り"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Hibi Plus 구입, $4.99 일회 결제"
+            "value": "Hibi Plus 구입, %@ 일회 결제"
           }
         },
         "ms": {
           "stringUnit": {
             "state": "translated",
-            "value": "Beli Hibi Plus, $4.99 sekali bayar"
+            "value": "Beli Hibi Plus, %@ sekali bayar"
           }
         },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
-            "value": "Comprar Hibi Plus, $4,99 pagamento único"
+            "value": "Comprar Hibi Plus, %@ pagamento único"
           }
         },
         "zh-Hans-CN": {
           "stringUnit": {
             "state": "translated",
-            "value": "购买 Hibi Plus，$4.99 一次性"
+            "value": "购买 Hibi Plus，%@ 一次性"
           }
         },
         "zh-Hant-HK": {
           "stringUnit": {
             "state": "translated",
-            "value": "購買 Hibi Plus，$4.99 一次性"
+            "value": "購買 Hibi Plus，%@ 一次性"
           }
         },
         "zh-Hant-TW": {
           "stringUnit": {
             "state": "translated",
-            "value": "購買 Hibi Plus，$4.99 一次性"
+            "value": "購買 Hibi Plus，%@ 一次性"
           }
+        }
+      }
+    },
+    "Locked. Unlock widgets with Hibi Plus in the app.": {
+      "comment": "Accessibility label for a locked Hibi Plus home-screen widget.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": { "state": "translated", "value": "Gesperrt. Schalte Widgets mit Hibi Plus in der App frei." }
+        },
+        "en": {
+          "stringUnit": { "state": "translated", "value": "Locked. Unlock widgets with Hibi Plus in the app." }
+        },
+        "es": {
+          "stringUnit": { "state": "translated", "value": "Bloqueado. Desbloquea los widgets con Hibi Plus en la app." }
+        },
+        "it": {
+          "stringUnit": { "state": "translated", "value": "Bloccato. Sblocca i widget con Hibi Plus nell’app." }
+        },
+        "ja": {
+          "stringUnit": { "state": "translated", "value": "ロック中です。アプリのHibi Plusでウィジェットのロックを解除できます。" }
+        },
+        "ko": {
+          "stringUnit": { "state": "translated", "value": "잠김. 앱에서 Hibi Plus로 위젯을 잠금 해제하세요." }
+        },
+        "ms": {
+          "stringUnit": { "state": "translated", "value": "Dikunci. Buka kunci widget dengan Hibi Plus dalam apl." }
+        },
+        "pt-BR": {
+          "stringUnit": { "state": "translated", "value": "Bloqueado. Desbloqueie os widgets com o Hibi Plus no app." }
+        },
+        "zh-Hans-CN": {
+          "stringUnit": { "state": "translated", "value": "已锁定。在 App 中通过 Hibi Plus 解锁小组件。" }
+        },
+        "zh-Hant-HK": {
+          "stringUnit": { "state": "translated", "value": "已鎖定。在 App 中透過 Hibi Plus 解鎖小工具。" }
+        },
+        "zh-Hant-TW": {
+          "stringUnit": { "state": "translated", "value": "已鎖定。在 App 中透過 Hibi Plus 解鎖小工具。" }
+        }
+      }
+    },
+    "Purchasing…": {
+      "comment": "Accessibility label while the StoreKit purchase sheet is in flight.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": { "state": "translated", "value": "Wird gekauft …" }
+        },
+        "en": {
+          "stringUnit": { "state": "translated", "value": "Purchasing…" }
+        },
+        "es": {
+          "stringUnit": { "state": "translated", "value": "Comprando…" }
+        },
+        "it": {
+          "stringUnit": { "state": "translated", "value": "Acquisto in corso…" }
+        },
+        "ja": {
+          "stringUnit": { "state": "translated", "value": "購入中…" }
+        },
+        "ko": {
+          "stringUnit": { "state": "translated", "value": "구매 중…" }
+        },
+        "ms": {
+          "stringUnit": { "state": "translated", "value": "Membeli…" }
+        },
+        "pt-BR": {
+          "stringUnit": { "state": "translated", "value": "Comprando…" }
+        },
+        "zh-Hans-CN": {
+          "stringUnit": { "state": "translated", "value": "购买中…" }
+        },
+        "zh-Hant-HK": {
+          "stringUnit": { "state": "translated", "value": "購買中…" }
+        },
+        "zh-Hant-TW": {
+          "stringUnit": { "state": "translated", "value": "購買中…" }
+        }
+      }
+    },
+    "Unlock widgets in the app": {
+      "comment": "Caption under the lock on a Hibi Plus home-screen widget.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": { "state": "translated", "value": "Widgets in der App freischalten" }
+        },
+        "en": {
+          "stringUnit": { "state": "translated", "value": "Unlock widgets in the app" }
+        },
+        "es": {
+          "stringUnit": { "state": "translated", "value": "Desbloquéalos en la app" }
+        },
+        "it": {
+          "stringUnit": { "state": "translated", "value": "Sblocca i widget nell’app" }
+        },
+        "ja": {
+          "stringUnit": { "state": "translated", "value": "アプリでロックを解除" }
+        },
+        "ko": {
+          "stringUnit": { "state": "translated", "value": "앱에서 위젯 잠금 해제" }
+        },
+        "ms": {
+          "stringUnit": { "state": "translated", "value": "Buka kunci dalam apl" }
+        },
+        "pt-BR": {
+          "stringUnit": { "state": "translated", "value": "Desbloqueie no app" }
+        },
+        "zh-Hans-CN": {
+          "stringUnit": { "state": "translated", "value": "在 App 中解锁小组件" }
+        },
+        "zh-Hant-HK": {
+          "stringUnit": { "state": "translated", "value": "在 App 中解鎖小工具" }
+        },
+        "zh-Hant-TW": {
+          "stringUnit": { "state": "translated", "value": "在 App 中解鎖小工具" }
         }
       }
     },

--- a/Hibi/Models/AppIconManager.swift
+++ b/Hibi/Models/AppIconManager.swift
@@ -25,6 +25,8 @@ struct AppIconOption: Identifiable, Sendable {
     enum Unlock: Sendable {
         case always
         case beforeDate(Date)
+        /// Unlocked only while the Hibi Plus entitlement is active.
+        case plus
     }
 }
 
@@ -35,6 +37,11 @@ struct AppIconOption: Identifiable, Sendable {
 final class AppIconManager {
     private(set) var selectedIconID: String
     private(set) var installDate: Date?
+
+    /// Mirrors the Hibi Plus entitlement. Owned by `PlusStore`; the view layer
+    /// pushes changes in so `.plus`-gated icons unlock the moment a purchase
+    /// completes (this is `@Observable`, so the icon list re-renders).
+    var isPlus: Bool = false
 
     static let icons: [AppIconOption] = {
         var cal = Calendar(identifier: .gregorian)
@@ -64,7 +71,7 @@ final class AppIconManager {
                 subtitle: "Available for Hibi Plus users",
                 previewAssetName: "AppIconPreview-DiscoBalloon",
                 alternateIconName: "DiscoBalloon",
-                unlock: .always
+                unlock: .plus
             ),
             AppIconOption(
                 id: "leatherbag",
@@ -72,7 +79,7 @@ final class AppIconManager {
                 subtitle: "Available for Hibi Plus users",
                 previewAssetName: "AppIconPreview-Leatherbag",
                 alternateIconName: "Leatherbag",
-                unlock: .always
+                unlock: .plus
             ),
             AppIconOption(
                 id: "pearl-hibi",
@@ -80,7 +87,7 @@ final class AppIconManager {
                 subtitle: "Available for Hibi Plus users",
                 previewAssetName: "AppIconPreview-PearlHibi",
                 alternateIconName: "PearlHibi",
-                unlock: .always
+                unlock: .plus
             ),
             AppIconOption(
                 id: "pixel-sun",
@@ -88,7 +95,7 @@ final class AppIconManager {
                 subtitle: "Available for Hibi Plus users",
                 previewAssetName: "AppIconPreview-PixelSun",
                 alternateIconName: "PixelSun",
-                unlock: .always
+                unlock: .plus
             ),
             AppIconOption(
                 id: "porcelain",
@@ -96,7 +103,7 @@ final class AppIconManager {
                 subtitle: "Available for Hibi Plus users",
                 previewAssetName: "AppIconPreview-Porcelain",
                 alternateIconName: "Porcelain",
-                unlock: .always
+                unlock: .plus
             ),
             AppIconOption(
                 id: "wood-stroke",
@@ -104,7 +111,7 @@ final class AppIconManager {
                 subtitle: "Available for Hibi Plus users",
                 previewAssetName: "AppIconPreview-WoodStroke",
                 alternateIconName: "WoodStroke",
-                unlock: .always
+                unlock: .plus
             ),
         ]
     }()
@@ -157,12 +164,24 @@ final class AppIconManager {
     }
 
     func isUnlocked(_ option: AppIconOption) -> Bool {
+        Self.isUnlocked(option, isPlus: isPlus, installDate: installDate)
+    }
+
+    /// Pure unlock rule, factored out so it can be unit-tested without a
+    /// `UIApplication`.
+    static func isUnlocked(
+        _ option: AppIconOption,
+        isPlus: Bool,
+        installDate: Date?
+    ) -> Bool {
         switch option.unlock {
         case .always:
             return true
         case .beforeDate(let cutoff):
-            guard let install = installDate else { return false }
-            return install < cutoff
+            guard let installDate else { return false }
+            return installDate < cutoff
+        case .plus:
+            return isPlus
         }
     }
 

--- a/Hibi/Models/PlusEntitlement.swift
+++ b/Hibi/Models/PlusEntitlement.swift
@@ -22,6 +22,7 @@ enum PlusProduct {
 struct PlusEntitlementStore {
     static let entitledKey = "hibiPlusEntitled.v1"
     static let purchaseDateKey = "hibiPlusPurchaseDate.v1"
+    static let seedUUIDKey = "hibiPlusStampSeedUUID.v1"
 
     let defaults: UserDefaults?
 
@@ -33,11 +34,19 @@ struct PlusEntitlementStore {
         defaults?.bool(forKey: Self.entitledKey) ?? false
     }
 
-    /// The date the entitlement was first granted. Used to seed the stamp so
-    /// it renders identically across launches (the stamp art is derived from
-    /// this date). `nil` until a purchase is recorded.
+    /// The date the entitlement was first granted. Shown as the dated text on
+    /// the stamp. `nil` until a purchase is recorded.
     var purchaseDate: Date? {
         defaults?.object(forKey: Self.purchaseDateKey) as? Date
+    }
+
+    /// Stable UUID that seeds the stamp's design and ink noise (the StoreKit
+    /// transaction's `appAccountToken`, or a deterministic fallback). Cached
+    /// here so the stamp renders identically across launches without
+    /// re-querying StoreKit. `nil` until a purchase is recorded.
+    var seedUUID: UUID? {
+        guard let raw = defaults?.string(forKey: Self.seedUUIDKey) else { return nil }
+        return UUID(uuidString: raw)
     }
 
     func setIsPlus(_ value: Bool) {
@@ -49,6 +58,14 @@ struct PlusEntitlementStore {
             defaults?.set(date, forKey: Self.purchaseDateKey)
         } else {
             defaults?.removeObject(forKey: Self.purchaseDateKey)
+        }
+    }
+
+    func setSeedUUID(_ uuid: UUID?) {
+        if let uuid {
+            defaults?.set(uuid.uuidString, forKey: Self.seedUUIDKey)
+        } else {
+            defaults?.removeObject(forKey: Self.seedUUIDKey)
         }
     }
 }

--- a/Hibi/Models/PlusEntitlement.swift
+++ b/Hibi/Models/PlusEntitlement.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+/// Identifiers for the single Hibi Plus in-app purchase.
+///
+/// One non-consumable unlocks every Plus perk (extra app icons, the
+/// personalized stamp, home-screen widgets). The identifier must match the
+/// product configured in App Store Connect and in `Hibi.storekit`.
+enum PlusProduct {
+    static let id = "com.weichart.hibi.plus"
+}
+
+/// App-Group-backed mirror of the Hibi Plus entitlement.
+///
+/// `PlusStore` (app target, StoreKit) is the source of truth: it writes here
+/// whenever the verified entitlement changes. The widget extension — which
+/// can't run a purchase flow — reads this synchronously to decide whether to
+/// show the locked overlay. Both sides share the same App Group suite, so a
+/// purchase in the app is visible to the widget after a timeline reload.
+///
+/// `defaults` is injectable so the unlock logic can be unit-tested against an
+/// isolated suite instead of the real shared store.
+struct PlusEntitlementStore {
+    static let entitledKey = "hibiPlusEntitled.v1"
+    static let purchaseDateKey = "hibiPlusPurchaseDate.v1"
+
+    let defaults: UserDefaults?
+
+    init(defaults: UserDefaults? = AppGroup.defaults) {
+        self.defaults = defaults
+    }
+
+    var isPlus: Bool {
+        defaults?.bool(forKey: Self.entitledKey) ?? false
+    }
+
+    /// The date the entitlement was first granted. Used to seed the stamp so
+    /// it renders identically across launches (the stamp art is derived from
+    /// this date). `nil` until a purchase is recorded.
+    var purchaseDate: Date? {
+        defaults?.object(forKey: Self.purchaseDateKey) as? Date
+    }
+
+    func setIsPlus(_ value: Bool) {
+        defaults?.set(value, forKey: Self.entitledKey)
+    }
+
+    func setPurchaseDate(_ date: Date?) {
+        if let date {
+            defaults?.set(date, forKey: Self.purchaseDateKey)
+        } else {
+            defaults?.removeObject(forKey: Self.purchaseDateKey)
+        }
+    }
+}

--- a/Hibi/Models/PlusStore.swift
+++ b/Hibi/Models/PlusStore.swift
@@ -1,0 +1,145 @@
+import Foundation
+import Observation
+import StoreKit
+import WidgetKit
+
+/// Owns the Hibi Plus entitlement and the StoreKit 2 purchase flow.
+///
+/// Source of truth for "is this user Plus?" across the app. On every verified
+/// entitlement change it mirrors the result into the shared App Group via
+/// `PlusEntitlementStore` and reloads widget timelines, so the locked widget
+/// overlay clears the moment a purchase completes.
+///
+/// `isPlus` is seeded synchronously from the App Group cache in `init` so the
+/// UI never flashes a "locked" state on launch for an existing Plus user;
+/// `start()` then reconciles against StoreKit's current entitlements.
+@Observable
+@MainActor
+final class PlusStore {
+    private(set) var isPlus: Bool
+    private(set) var purchaseDate: Date?
+    private(set) var product: Product?
+    private(set) var isPurchasing = false
+
+    /// Localized, ready-to-display price (e.g. "$4.99"). `nil` until the
+    /// product loads; views fall back to a hard-coded placeholder.
+    var displayPrice: String? { product?.displayPrice }
+
+    private let entitlement: PlusEntitlementStore
+    private var updatesTask: Task<Void, Never>?
+
+    init(entitlement: PlusEntitlementStore = PlusEntitlementStore()) {
+        self.entitlement = entitlement
+        self.isPlus = entitlement.isPlus
+        self.purchaseDate = entitlement.purchaseDate
+    }
+
+    /// Begin listening for transaction updates and reconcile current state.
+    /// Idempotent — safe to call from `.task` on every appearance.
+    func start() {
+        if updatesTask == nil {
+            updatesTask = Task { [weak self] in
+                for await update in Transaction.updates {
+                    await self?.handle(update)
+                }
+            }
+        }
+        Task { await loadProduct() }
+        Task { await refreshEntitlement() }
+    }
+
+    func loadProduct() async {
+        do {
+            let products = try await Product.products(for: [PlusProduct.id])
+            product = products.first
+        } catch {
+            #if DEBUG
+            print("[PlusStore] product load failed: \(error)")
+            #endif
+        }
+    }
+
+    /// Recompute the entitlement from StoreKit's current entitlements. This is
+    /// what restores a purchase on a new device/reinstall.
+    func refreshEntitlement() async {
+        var entitled = false
+        var date: Date?
+        for await result in Transaction.currentEntitlements {
+            guard case .verified(let transaction) = result,
+                  transaction.productID == PlusProduct.id,
+                  transaction.revocationDate == nil else { continue }
+            entitled = true
+            date = transaction.purchaseDate
+        }
+        apply(entitled: entitled, date: date)
+    }
+
+    /// Run the purchase sheet. Returns `true` only on a verified success.
+    @discardableResult
+    func purchase() async -> Bool {
+        guard let product, !isPurchasing else { return false }
+        isPurchasing = true
+        defer { isPurchasing = false }
+
+        do {
+            let result = try await product.purchase()
+            switch result {
+            case .success(let verification):
+                guard case .verified(let transaction) = verification else { return false }
+                await transaction.finish()
+                apply(entitled: true, date: transaction.purchaseDate)
+                return true
+            case .userCancelled, .pending:
+                return false
+            @unknown default:
+                return false
+            }
+        } catch {
+            #if DEBUG
+            print("[PlusStore] purchase failed: \(error)")
+            #endif
+            return false
+        }
+    }
+
+    /// Ask the App Store to sync transactions (the "Restore Purchases" path),
+    /// then re-evaluate the entitlement.
+    func restore() async {
+        try? await AppStore.sync()
+        await refreshEntitlement()
+    }
+
+    private func handle(_ result: VerificationResult<Transaction>) async {
+        guard case .verified(let transaction) = result else { return }
+        await transaction.finish()
+        await refreshEntitlement()
+    }
+
+    /// Persist to the App Group and, if the entitlement actually flipped,
+    /// publish the change and refresh widgets.
+    private func apply(entitled: Bool, date: Date?) {
+        entitlement.setIsPlus(entitled)
+        if entitled {
+            // Keep the earliest known purchase date stable across refreshes so
+            // the derived stamp art never changes once granted.
+            let resolved = entitlement.purchaseDate ?? date ?? Date()
+            entitlement.setPurchaseDate(resolved)
+            purchaseDate = resolved
+        } else {
+            entitlement.setPurchaseDate(nil)
+            purchaseDate = nil
+        }
+
+        if isPlus != entitled {
+            isPlus = entitled
+            WidgetCenter.shared.reloadAllTimelines()
+        }
+    }
+
+    #if DEBUG
+    /// Bypass StoreKit for local UI testing (wired to the Settings debug row).
+    func debugSetPlus(_ value: Bool) {
+        apply(entitled: value, date: value ? Date() : nil)
+    }
+    #endif
+}

--- a/Hibi/Models/PlusStore.swift
+++ b/Hibi/Models/PlusStore.swift
@@ -18,6 +18,8 @@ import WidgetKit
 final class PlusStore {
     private(set) var isPlus: Bool
     private(set) var purchaseDate: Date?
+    /// Stable UUID that seeds the personalized stamp (see `PlusEntitlementStore`).
+    private(set) var seedUUID: UUID?
     private(set) var product: Product?
     private(set) var isPurchasing = false
 
@@ -32,6 +34,7 @@ final class PlusStore {
         self.entitlement = entitlement
         self.isPlus = entitlement.isPlus
         self.purchaseDate = entitlement.purchaseDate
+        self.seedUUID = entitlement.seedUUID
     }
 
     /// Begin listening for transaction updates and reconcile current state.
@@ -64,14 +67,16 @@ final class PlusStore {
     func refreshEntitlement() async {
         var entitled = false
         var date: Date?
+        var uuid: UUID?
         for await result in Transaction.currentEntitlements {
             guard case .verified(let transaction) = result,
                   transaction.productID == PlusProduct.id,
                   transaction.revocationDate == nil else { continue }
             entitled = true
             date = transaction.purchaseDate
+            uuid = Self.seedUUID(for: transaction)
         }
-        apply(entitled: entitled, date: date)
+        apply(entitled: entitled, date: date, uuid: uuid)
     }
 
     /// Run the purchase sheet. Returns `true` only on a verified success.
@@ -82,12 +87,18 @@ final class PlusStore {
         defer { isPurchasing = false }
 
         do {
-            let result = try await product.purchase()
+            // Bind a stable UUID to this purchase. StoreKit persists it on the
+            // transaction (and returns it via `appAccountToken` on restore /
+            // reinstall), so the stamp it seeds stays identical forever.
+            let token = entitlement.seedUUID ?? UUID()
+            let result = try await product.purchase(options: [.appAccountToken(token)])
             switch result {
             case .success(let verification):
                 guard case .verified(let transaction) = verification else { return false }
                 await transaction.finish()
-                apply(entitled: true, date: transaction.purchaseDate)
+                apply(entitled: true,
+                      date: transaction.purchaseDate,
+                      uuid: Self.seedUUID(for: transaction) ?? token)
                 return true
             case .userCancelled, .pending:
                 return false
@@ -117,17 +128,24 @@ final class PlusStore {
 
     /// Persist to the App Group and, if the entitlement actually flipped,
     /// publish the change and refresh widgets.
-    private func apply(entitled: Bool, date: Date?) {
+    ///
+    /// The purchase date and seed UUID are written *once* and then kept stable
+    /// across subsequent refreshes — the stamp's design and dated text must
+    /// never change after it's been granted.
+    private func apply(entitled: Bool, date: Date?, uuid: UUID?) {
         entitlement.setIsPlus(entitled)
         if entitled {
-            // Keep the earliest known purchase date stable across refreshes so
-            // the derived stamp art never changes once granted.
-            let resolved = entitlement.purchaseDate ?? date ?? Date()
-            entitlement.setPurchaseDate(resolved)
-            purchaseDate = resolved
+            let resolvedDate = entitlement.purchaseDate ?? date ?? Date()
+            let resolvedUUID = entitlement.seedUUID ?? uuid ?? UUID()
+            entitlement.setPurchaseDate(resolvedDate)
+            entitlement.setSeedUUID(resolvedUUID)
+            purchaseDate = resolvedDate
+            seedUUID = resolvedUUID
         } else {
             entitlement.setPurchaseDate(nil)
+            entitlement.setSeedUUID(nil)
             purchaseDate = nil
+            seedUUID = nil
         }
 
         if isPlus != entitled {
@@ -136,10 +154,30 @@ final class PlusStore {
         }
     }
 
+    /// The stamp seed UUID for a transaction: the `appAccountToken` we set at
+    /// purchase, or — for legacy/restored purchases that predate it — a UUID
+    /// derived deterministically from the original transaction ID so it stays
+    /// stable across devices.
+    private static func seedUUID(for transaction: Transaction) -> UUID? {
+        transaction.appAccountToken ?? stableUUID(from: transaction.originalID)
+    }
+
+    /// Deterministically expands a 64-bit value into a UUID (splitmix64 fill).
+    private static func stableUUID(from value: UInt64) -> UUID {
+        let lo = value
+        let hi = value &* 0x9E37_79B9_7F4A_7C15
+        var b = [UInt8](repeating: 0, count: 16)
+        withUnsafeBytes(of: hi.bigEndian) { for i in 0..<8 { b[i] = $0[i] } }
+        withUnsafeBytes(of: lo.bigEndian) { for i in 0..<8 { b[8 + i] = $0[i] } }
+        return UUID(uuid: (b[0], b[1], b[2], b[3], b[4], b[5], b[6], b[7],
+                           b[8], b[9], b[10], b[11], b[12], b[13], b[14], b[15]))
+    }
+
     #if DEBUG
     /// Bypass StoreKit for local UI testing (wired to the Settings debug row).
+    /// Generates a one-off seed UUID so the debug stamp looks like a real one.
     func debugSetPlus(_ value: Bool) {
-        apply(entitled: value, date: value ? Date() : nil)
+        apply(entitled: value, date: value ? Date() : nil, uuid: nil)
     }
     #endif
 }

--- a/Hibi/Models/StampConfig.swift
+++ b/Hibi/Models/StampConfig.swift
@@ -67,8 +67,28 @@ nonisolated enum StampConfig {
 
     // MARK: - Seed
 
-    /// Placeholder seed derived from the purchase date.
-    /// TODO: Replace with IAP Transaction UUID once StoreKit 2 is wired up.
+    /// Stable randomness seed derived from the purchase's UUID (the StoreKit
+    /// transaction's `appAccountToken`). This is the production source: it
+    /// picks the stamp design and drives the shader's ink noise, and stays
+    /// identical for the lifetime of the purchase regardless of the displayed
+    /// date.
+    ///
+    /// Hashes the 16 UUID bytes (FNV-1a) and masks to 24 bits: `Float` only
+    /// represents integers exactly up to 2^24, and the seed round-trips
+    /// through `.float()` into the Metal shader.
+    static func seed(from uuid: UUID) -> UInt64 {
+        var hash: UInt64 = 0xcbf2_9ce4_8422_2325
+        withUnsafeBytes(of: uuid.uuid) { raw in
+            for byte in raw {
+                hash ^= UInt64(byte)
+                hash = hash &* 0x0000_0100_0000_01b3
+            }
+        }
+        return hash & 0x00FF_FFFF
+    }
+
+    /// Date-derived seed. Retained for the DEBUG stamp-noise preview, which
+    /// has no purchase UUID to key off. Production uses `seed(from: UUID)`.
     ///
     /// The packed date value can exceed 2^24 (~16.7M), but `Float` only
     /// represents integers exactly up to 2^24. We hash through a Wang hash

--- a/Hibi/Views/HibiPlusView.swift
+++ b/Hibi/Views/HibiPlusView.swift
@@ -384,15 +384,21 @@ struct WidgetsTile: View {
 struct PlusCTA: View {
     /// True once the success morph has played; owner drives the rest.
     @Binding var showSuccess: Bool
+    /// StoreKit purchase sheet is in flight (before success is known).
+    var isPurchasing: Bool = false
     var isGenerating: Bool = false
+    /// Localized price, e.g. "$4.99". Falls back to the placeholder default.
+    var price: String = "$4.99"
     let onPurchase: () -> Void
 
+    /// Any in-flight or completed state — blocks re-taps.
+    private var isBusy: Bool { showSuccess || isGenerating || isPurchasing }
+    /// Drives the green "success" colorway (only once the purchase landed).
     private var isActive: Bool { showSuccess || isGenerating }
 
     var body: some View {
         Button {
-            guard !showSuccess else { return }
-            withAnimation(.spring(response: 0.35, dampingFraction: 0.7)) { showSuccess = true }
+            guard !isBusy else { return }
             onPurchase()
         } label: {
             Group {
@@ -411,9 +417,14 @@ struct PlusCTA: View {
                         Text("Thank you")
                             .font(.system(size: 15, weight: .semibold))
                     }
+                } else if isPurchasing {
+                    ProgressView()
+                        .tint(PaperTints.card1)
+                        .scaleEffect(0.9)
+                        .frame(height: 18)
                 } else {
                     HStack(alignment: .firstTextBaseline, spacing: 8) {
-                        Text(verbatim: "$4.99")
+                        Text(verbatim: price)
                             .font(.system(size: 15, weight: .medium, design: .monospaced))
                         Text("one-time")
                             .font(.custom(AppFont.serifItalic, size: 12.5))
@@ -432,16 +443,17 @@ struct PlusCTA: View {
         .accessibilityLabel(
             isGenerating ? Text("Generating your stamp") :
             showSuccess ? Text("Purchased. Thank you.") :
-            Text("Buy Hibi Plus, $4.99 one-time")
+            isPurchasing ? Text("Purchasing…") :
+            Text("Buy Hibi Plus, \(price) one-time")
         )
     }
 }
 
 struct RestorePurchasesLink: View {
+    let onRestore: () -> Void
+
     var body: some View {
-        Button {
-            // No-op placeholder — no real IAP yet.
-        } label: {
+        Button(action: onRestore) {
             Text("Restore purchases")
                 .font(.custom(AppFont.serifItalic, size: 11.5))
                 .foregroundStyle(.tertiary)
@@ -518,8 +530,11 @@ private struct FeatureCardBody: View {
     let purchased: Bool
     let chromeFade: Double
     @Binding var ctaSuccess: Bool
+    var isPurchasing: Bool = false
     var isGenerating: Bool = false
+    var price: String = "$4.99"
     let onPurchase: () -> Void
+    let onRestore: () -> Void
     @AppStorage("useSimpleFont", store: AppGroup.defaults) private var useSimpleFont = false
 
     var body: some View {
@@ -574,8 +589,12 @@ private struct FeatureCardBody: View {
 
                 if !purchased {
                     VStack(spacing: 8) {
-                        PlusCTA(showSuccess: $ctaSuccess, isGenerating: isGenerating, onPurchase: onPurchase)
-                        RestorePurchasesLink()
+                        PlusCTA(showSuccess: $ctaSuccess,
+                                isPurchasing: isPurchasing,
+                                isGenerating: isGenerating,
+                                price: price,
+                                onPurchase: onPurchase)
+                        RestorePurchasesLink(onRestore: onRestore)
                     }
                     .opacity(chromeFade)
                     .padding(.bottom, 58 * chromeFade)
@@ -635,8 +654,9 @@ struct HibiPlusView: View {
     private var chromeFade: Double {
         Double(max(0, 1 - collapseProgress * 1.25))
     }
-    @State private var isPlus = false
-    @State private var purchaseDate: Date?
+    @Environment(PlusStore.self) private var plusStore
+    private var isPlus: Bool { plusStore.isPlus }
+    private var purchaseDate: Date? { plusStore.purchaseDate }
 
     // animation state
     @State private var dragY: CGFloat = 0
@@ -644,6 +664,7 @@ struct HibiPlusView: View {
     @State private var cardShift: CGFloat = 0          // 0…1, back rises to front
     @State private var commitCount = 0                 // haptic
     @State private var ctaSuccess = false
+    @State private var isPurchasing = false
     @State private var stampToken = 0
     @State private var isGeneratingStamp = false
     @State private var generationTask: Task<Void, Never>?
@@ -847,8 +868,12 @@ struct HibiPlusView: View {
                           chromeFade: chromeFade, stampToken: stampToken)
         } else {
             FeatureCardBody(purchased: isPlus, chromeFade: chromeFade,
-                            ctaSuccess: $ctaSuccess, isGenerating: isGeneratingStamp,
-                            onPurchase: purchase)
+                            ctaSuccess: $ctaSuccess,
+                            isPurchasing: isPurchasing,
+                            isGenerating: isGeneratingStamp,
+                            price: plusStore.displayPrice ?? "$4.99",
+                            onPurchase: purchase,
+                            onRestore: restore)
         }
     }
 
@@ -911,20 +936,32 @@ struct HibiPlusView: View {
         }
     }
 
-    /// CTA tapped: success morph has already started (PlusCTA set ctaSuccess).
-    /// Pre-generate the stamp composite so flipping to the stamp card is instant.
+    /// CTA tapped: run the StoreKit purchase. The CTA shows a spinner while the
+    /// system sheet is up; only a verified success plays the celebratory
+    /// checkmark → stamp-generation → flip sequence. Cancel/failure quietly
+    /// returns to the price.
     private func purchase() {
-        let date = Date()
-        purchaseDate = date
-        let scale = displayScale
+        guard !isPurchasing else { return }
+        isPurchasing = true
+        Task {
+            let success = await plusStore.purchase()
+            isPurchasing = false
+            guard success else { return }
+            withAnimation(.spring(response: 0.35, dampingFraction: 0.7)) {
+                ctaSuccess = true
+            }
+            beginStampReveal()
+        }
+    }
 
-        // Capture values before entering detached context.
-        let seed = StampConfig.seed(from: date)
-        let def = StampConfig.definition(for: seed)
+    /// Pre-generate the stamp composite (seeded from the recorded purchase
+    /// date) so flipping to the stamp card is instant, then flip.
+    private func beginStampReveal() {
+        let date = purchaseDate ?? Date()
+        let scale = displayScale
+        let def = StampConfig.definition(for: StampConfig.seed(from: date))
         let compositeSize = HibiStamp.compositeSize
 
-        // Start composite generation immediately so the cache is warm
-        // before the stamp card appears.
         generationTask?.cancel()
         generationTask = Task.detached(priority: .userInitiated) {
             guard let def else { return }
@@ -934,22 +971,27 @@ struct HibiPlusView: View {
             )
         }
 
-        // 1) Show checkmark for 0.8s, then switch to "Generating…" on the CTA
+        // Show checkmark for 0.8s, then switch to "Generating…" on the CTA.
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.8) {
             withAnimation(.easeInOut(duration: 0.25)) { isGeneratingStamp = true }
         }
 
-        // 2) Wait for composite to finish, then flip to stamp card
+        // Wait for the composite to finish, then flip to the stamp card.
         Task {
             await generationTask?.value
             await MainActor.run { finishPurchaseFlip() }
         }
     }
 
+    /// Restore a prior purchase (e.g. on a new device). On success the
+    /// entitlement flips and the card collapses into its Plus state.
+    private func restore() {
+        Task { await plusStore.restore() }
+    }
+
     /// Flips to the stamp card and stamps once the composite is ready.
     private func finishPurchaseFlip() {
         isGeneratingStamp = false
-        isPlus = true
 
         if frontIndex != 0 {
             isAnimating = true

--- a/Hibi/Views/HibiPlusView.swift
+++ b/Hibi/Views/HibiPlusView.swift
@@ -22,6 +22,10 @@ private enum HPLayout {
 
 struct HibiStamp: View {
     let purchased: Bool
+    /// Drives the stamp design choice and the shader's ink noise. Derived from
+    /// the purchase UUID (stable), independent of the displayed `date`.
+    let seed: UInt64
+    /// The purchase date, rendered as the dated text on the stamp.
     let date: Date?
     var size: CGFloat = 154
     var rotation: Double = -6
@@ -93,6 +97,7 @@ struct HibiStamp: View {
         }
         .onAppear { buildComposite() }
         .onChange(of: date) { _, _ in buildComposite() }
+        .onChange(of: seed) { _, _ in buildComposite() }
         .onChange(of: stampToken) { _, _ in
             appeared = false
             buildComposite()
@@ -109,7 +114,7 @@ struct HibiStamp: View {
             .layerEffect(
                 ShaderLibrary.stampEffect(
                     .float2(Float(size), Float(size)),
-                    .float(Float(StampConfig.seed(from: date ?? Date()))),
+                    .float(Float(seed)),
                     .float2(0, 0),
                     .color(PaperTints.sealInk),
                     .floatArray(noiseValues)
@@ -125,7 +130,7 @@ struct HibiStamp: View {
             .layerEffect(
                 ShaderLibrary.stampEffect(
                     .float2(Float(size), Float(size)),
-                    .float(Float(StampConfig.seed(from: date ?? Date()))),
+                    .float(Float(seed)),
                     .float2(Float(motion.tiltX), Float(motion.tiltY)),
                     .color(PaperTints.sealInk),
                     .floatArray(noiseValues)
@@ -141,7 +146,6 @@ struct HibiStamp: View {
     private func buildComposite() {
         compositeTask?.cancel()
         guard let date else { compositeImage = nil; return }
-        let seed = StampConfig.seed(from: date)
         guard let def = StampConfig.definition(for: seed) else { compositeImage = nil; return }
         let scale = displayScale
         let compositeSize = Self.compositeSize
@@ -494,6 +498,7 @@ private struct PlusHeader: View {
 
 private struct StampCardBody: View {
     let purchased: Bool
+    let seed: UInt64
     let date: Date?
     let expandFraction: CGFloat
     let chromeFade: Double
@@ -505,7 +510,7 @@ private struct StampCardBody: View {
             + (HPLayout.stampExpandedHeight - HPLayout.collapsed.height) * expandFraction
 
         ZStack {
-            HibiStamp(purchased: purchased, date: date,
+            HibiStamp(purchased: purchased, seed: seed, date: date,
                       size: 200 + 110 * expandFraction, stampToken: stampToken)
                 .frame(maxWidth: .infinity)
 
@@ -657,6 +662,13 @@ struct HibiPlusView: View {
     @Environment(PlusStore.self) private var plusStore
     private var isPlus: Bool { plusStore.isPlus }
     private var purchaseDate: Date? { plusStore.purchaseDate }
+    /// Stamp randomness seed: derived from the cached purchase UUID, falling
+    /// back to the date only if no UUID has been recorded yet.
+    private var stampSeed: UInt64 {
+        if let uuid = plusStore.seedUUID { return StampConfig.seed(from: uuid) }
+        if let date = purchaseDate { return StampConfig.seed(from: date) }
+        return 0
+    }
 
     // animation state
     @State private var dragY: CGFloat = 0
@@ -863,7 +875,7 @@ struct HibiPlusView: View {
     @ViewBuilder
     private func cardBody(index: Int) -> some View {
         if index == 0 {
-            StampCardBody(purchased: isPlus, date: purchaseDate,
+            StampCardBody(purchased: isPlus, seed: stampSeed, date: purchaseDate,
                           expandFraction: 1 - collapseProgress,
                           chromeFade: chromeFade, stampToken: stampToken)
         } else {
@@ -959,7 +971,7 @@ struct HibiPlusView: View {
     private func beginStampReveal() {
         let date = purchaseDate ?? Date()
         let scale = displayScale
-        let def = StampConfig.definition(for: StampConfig.seed(from: date))
+        let def = StampConfig.definition(for: stampSeed)
         let compositeSize = HibiStamp.compositeSize
 
         generationTask?.cancel()

--- a/Hibi/Views/SettingsView.swift
+++ b/Hibi/Views/SettingsView.swift
@@ -207,6 +207,9 @@ struct SettingsView: View {
 
                 settingsDivider
                 IconLockDebugRow()
+
+                settingsDivider
+                PlusDebugRow()
             }
             #endif
         }
@@ -465,6 +468,22 @@ private struct IconLockDebugRow: View {
             let date: Date = locked ? .distantFuture : .distantPast
             iconManager.overrideInstallDate(date)
         }
+    }
+}
+
+private struct PlusDebugRow: View {
+    @Environment(PlusStore.self) private var plusStore
+
+    var body: some View {
+        Toggle(isOn: Binding(
+            get: { plusStore.isPlus },
+            set: { plusStore.debugSetPlus($0) }
+        )) {
+            Label("Hibi Plus (debug)", systemImage: "seal")
+        }
+        .tint(.black)
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
     }
 }
 #endif

--- a/Hibi/Views/SettingsView.swift
+++ b/Hibi/Views/SettingsView.swift
@@ -356,7 +356,7 @@ private struct StampNoiseDebugView: View {
     var body: some View {
         VStack(spacing: 0) {
             // Sticky preview — always visible while the parameters scroll.
-            HibiStamp(purchased: true, date: previewDate, size: 180)
+            HibiStamp(purchased: true, seed: StampConfig.seed(from: previewDate), date: previewDate, size: 180)
                 .frame(maxWidth: .infinity)
                 .padding(.vertical, 14)
                 .background(Color(.systemGroupedBackground))

--- a/HibiTests/AppIconUnlockTests.swift
+++ b/HibiTests/AppIconUnlockTests.swift
@@ -1,0 +1,73 @@
+import Foundation
+import XCTest
+@testable import Hibi
+
+/// Verifies the app-icon gating rules: exactly two icons are free (the default
+/// and the early-user perk), and every other icon is behind Hibi Plus.
+@MainActor
+final class AppIconUnlockTests: XCTestCase {
+
+    private func icon(_ id: String) -> AppIconOption {
+        guard let option = AppIconManager.icons.first(where: { $0.id == id }) else {
+            fatalError("Missing icon option: \(id)")
+        }
+        return option
+    }
+
+    private func date(_ iso: String) -> Date {
+        ISO8601DateFormatter().date(from: iso)!
+    }
+
+    func testDefaultIconIsAlwaysFree() {
+        let def = icon("default")
+        XCTAssertTrue(AppIconManager.isUnlocked(def, isPlus: false, installDate: nil))
+        XCTAssertTrue(AppIconManager.isUnlocked(def, isPlus: true, installDate: Date()))
+    }
+
+    func testPlusIconRequiresEntitlement() {
+        let disco = icon("disco-balloon")
+        XCTAssertFalse(AppIconManager.isUnlocked(disco, isPlus: false, installDate: Date()))
+        XCTAssertTrue(AppIconManager.isUnlocked(disco, isPlus: true, installDate: nil))
+    }
+
+    func testEarlyUserUnlockedByInstallDateNotPlus() {
+        let early = icon("early-user")
+        // No recorded install date → locked.
+        XCTAssertFalse(AppIconManager.isUnlocked(early, isPlus: false, installDate: nil))
+        // Installed before the 2026-07-01 cutoff → unlocked even without Plus.
+        XCTAssertTrue(AppIconManager.isUnlocked(
+            early, isPlus: false, installDate: date("2026-01-01T00:00:00Z")))
+        // Installed after the cutoff → locked even *with* Plus (it's an
+        // early-adopter perk, not a Plus perk).
+        XCTAssertFalse(AppIconManager.isUnlocked(
+            early, isPlus: true, installDate: date("2026-12-01T00:00:00Z")))
+    }
+
+    func testExactlyTwoIconsAreFreeOfPlus() {
+        var alwaysCount = 0
+        var beforeDateCount = 0
+        var plusCount = 0
+        for option in AppIconManager.icons {
+            switch option.unlock {
+            case .always: alwaysCount += 1
+            case .beforeDate: beforeDateCount += 1
+            case .plus: plusCount += 1
+            }
+        }
+        XCTAssertEqual(alwaysCount, 1, "Exactly one always-free icon (Default)")
+        XCTAssertEqual(beforeDateCount, 1, "Exactly one early-user icon")
+        XCTAssertEqual(plusCount, 6, "The remaining six icons are Plus-gated")
+    }
+
+    func testAllPlusIconsTrackEntitlement() {
+        for option in AppIconManager.icons {
+            guard case .plus = option.unlock else { continue }
+            XCTAssertFalse(
+                AppIconManager.isUnlocked(option, isPlus: false, installDate: Date()),
+                "\(option.id) must be locked without Plus")
+            XCTAssertTrue(
+                AppIconManager.isUnlocked(option, isPlus: true, installDate: Date()),
+                "\(option.id) must unlock with Plus")
+        }
+    }
+}

--- a/HibiTests/PlusEntitlementStoreTests.swift
+++ b/HibiTests/PlusEntitlementStoreTests.swift
@@ -1,0 +1,58 @@
+import Foundation
+import XCTest
+@testable import Hibi
+
+/// Verifies the App-Group-backed entitlement mirror that `PlusStore` writes to
+/// and the widget reads from. Uses isolated `UserDefaults` suites so tests
+/// never touch the real shared store.
+@MainActor
+final class PlusEntitlementStoreTests: XCTestCase {
+
+    /// A clean, uniquely-named suite per test (keyed off the calling method) so
+    /// cases stay independent without a shared `setUp`/`tearDown`.
+    private func freshDefaults(_ name: String = #function) -> UserDefaults {
+        let suite = "com.weichart.hibi.tests.\(name)"
+        UserDefaults().removePersistentDomain(forName: suite)
+        return UserDefaults(suiteName: suite)!
+    }
+
+    func testDefaultsToNotPlus() {
+        let store = PlusEntitlementStore(defaults: freshDefaults())
+        XCTAssertFalse(store.isPlus)
+        XCTAssertNil(store.purchaseDate)
+    }
+
+    func testPersistsEntitlementAcrossInstances() {
+        let defaults = freshDefaults()
+        PlusEntitlementStore(defaults: defaults).setIsPlus(true)
+        XCTAssertTrue(PlusEntitlementStore(defaults: defaults).isPlus)
+
+        PlusEntitlementStore(defaults: defaults).setIsPlus(false)
+        XCTAssertFalse(PlusEntitlementStore(defaults: defaults).isPlus)
+    }
+
+    func testPersistsAndClearsPurchaseDate() {
+        let defaults = freshDefaults()
+        let date = Date(timeIntervalSince1970: 1_700_000_000)
+
+        PlusEntitlementStore(defaults: defaults).setPurchaseDate(date)
+        XCTAssertEqual(PlusEntitlementStore(defaults: defaults).purchaseDate, date)
+
+        PlusEntitlementStore(defaults: defaults).setPurchaseDate(nil)
+        XCTAssertNil(PlusEntitlementStore(defaults: defaults).purchaseDate)
+    }
+
+    func testNilDefaultsIsSafe() {
+        let store = PlusEntitlementStore(defaults: nil)
+        XCTAssertFalse(store.isPlus)
+        store.setIsPlus(true)            // must not crash
+        store.setPurchaseDate(Date())    // must not crash
+        XCTAssertFalse(store.isPlus)
+        XCTAssertNil(store.purchaseDate)
+    }
+
+    func testProductIdentifierContract() {
+        // The product ID must match App Store Connect and Hibi.storekit.
+        XCTAssertEqual(PlusProduct.id, "com.weichart.hibi.plus")
+    }
+}

--- a/HibiTests/PlusEntitlementStoreTests.swift
+++ b/HibiTests/PlusEntitlementStoreTests.swift
@@ -20,6 +20,18 @@ final class PlusEntitlementStoreTests: XCTestCase {
         let store = PlusEntitlementStore(defaults: freshDefaults())
         XCTAssertFalse(store.isPlus)
         XCTAssertNil(store.purchaseDate)
+        XCTAssertNil(store.seedUUID)
+    }
+
+    func testPersistsAndClearsSeedUUID() {
+        let defaults = freshDefaults()
+        let uuid = UUID()
+
+        PlusEntitlementStore(defaults: defaults).setSeedUUID(uuid)
+        XCTAssertEqual(PlusEntitlementStore(defaults: defaults).seedUUID, uuid)
+
+        PlusEntitlementStore(defaults: defaults).setSeedUUID(nil)
+        XCTAssertNil(PlusEntitlementStore(defaults: defaults).seedUUID)
     }
 
     func testPersistsEntitlementAcrossInstances() {
@@ -47,8 +59,10 @@ final class PlusEntitlementStoreTests: XCTestCase {
         XCTAssertFalse(store.isPlus)
         store.setIsPlus(true)            // must not crash
         store.setPurchaseDate(Date())    // must not crash
+        store.setSeedUUID(UUID())        // must not crash
         XCTAssertFalse(store.isPlus)
         XCTAssertNil(store.purchaseDate)
+        XCTAssertNil(store.seedUUID)
     }
 
     func testProductIdentifierContract() {

--- a/HibiTests/StampSeedTests.swift
+++ b/HibiTests/StampSeedTests.swift
@@ -1,0 +1,28 @@
+import Foundation
+import XCTest
+@testable import Hibi
+
+/// The stamp's randomness must be seeded from the purchase UUID and be stable:
+/// the same UUID always yields the same seed, and the value stays inside the
+/// 24-bit range the Metal shader requires.
+@MainActor
+final class StampSeedTests: XCTestCase {
+
+    func testSeedIsDeterministicForSameUUID() {
+        let uuid = UUID(uuidString: "11111111-2222-3333-4444-555555555555")!
+        XCTAssertEqual(StampConfig.seed(from: uuid), StampConfig.seed(from: uuid))
+    }
+
+    func testSeedStaysInFloatSafeRange() {
+        for _ in 0..<1000 {
+            XCTAssertLessThanOrEqual(StampConfig.seed(from: UUID()), 0x00FF_FFFF)
+        }
+    }
+
+    func testDistinctUUIDsRarelyCollide() {
+        var seeds = Set<UInt64>()
+        for _ in 0..<200 { seeds.insert(StampConfig.seed(from: UUID())) }
+        // 200 draws into a 24-bit space should almost never collide.
+        XCTAssertGreaterThan(seeds.count, 195)
+    }
+}

--- a/HibiWidgets/EventsWidgetView.swift
+++ b/HibiWidgets/EventsWidgetView.swift
@@ -15,7 +15,14 @@ struct EventsWidgetView: View {
 
     @Environment(\.widgetFamily) private var family
 
+    private var isPlus: Bool { PlusEntitlementStore().isPlus }
+
     var body: some View {
+        content.plusLocked(!isPlus)
+    }
+
+    @ViewBuilder
+    private var content: some View {
         switch family {
         case .systemLarge:
             EventsWidgetLargeBody(entry: entry)

--- a/HibiWidgets/PlusLockOverlay.swift
+++ b/HibiWidgets/PlusLockOverlay.swift
@@ -1,0 +1,56 @@
+import SwiftUI
+
+/// Locked-state treatment for the Hibi Plus widgets.
+///
+/// The user's real day still renders underneath — desaturated and dimmed — so
+/// the widget reads as "your schedule, behind a small paywall" rather than a
+/// blank placeholder. A centered lock chip with a short prompt sits on top.
+/// Cleared automatically once `PlusStore` records the entitlement and reloads
+/// timelines.
+struct PlusLockOverlay: ViewModifier {
+    func body(content: Content) -> some View {
+        content
+            .grayscale(1)
+            .opacity(0.5)
+            .overlay {
+                VStack(spacing: 3) {
+                    Image(systemName: "lock.fill")
+                        .font(.system(size: 18, weight: .semibold))
+                        .foregroundStyle(.primary)
+                    Text(verbatim: "Hibi Plus")
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundStyle(.primary)
+                    Text("Unlock widgets in the app")
+                        .font(.system(size: 9))
+                        .foregroundStyle(.secondary)
+                        .multilineTextAlignment(.center)
+                }
+                .padding(.vertical, 9)
+                .padding(.horizontal, 13)
+                .background(
+                    RoundedRectangle(cornerRadius: 13, style: .continuous)
+                        .fill(PaperTints.card1.opacity(0.92))
+                        .overlay {
+                            RoundedRectangle(cornerRadius: 13, style: .continuous)
+                                .strokeBorder(.primary.opacity(0.08), lineWidth: 0.5)
+                        }
+                        .shadow(color: .black.opacity(0.12), radius: 6, y: 2)
+                )
+                .padding(8)
+            }
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel(Text("Locked. Unlock widgets with Hibi Plus in the app."))
+    }
+}
+
+extension View {
+    /// Applies the Hibi Plus lock treatment when `locked` is `true`.
+    @ViewBuilder
+    func plusLocked(_ locked: Bool) -> some View {
+        if locked {
+            modifier(PlusLockOverlay())
+        } else {
+            self
+        }
+    }
+}

--- a/HibiWidgets/TodaysPageWidgetView.swift
+++ b/HibiWidgets/TodaysPageWidgetView.swift
@@ -6,7 +6,14 @@ struct TodaysPageWidgetView: View {
 
     @Environment(\.widgetFamily) private var family
 
+    private var isPlus: Bool { PlusEntitlementStore().isPlus }
+
     var body: some View {
+        content.plusLocked(!isPlus)
+    }
+
+    @ViewBuilder
+    private var content: some View {
         switch family {
         case .systemLarge:
             LargePaperView(entry: entry)


### PR DESCRIPTION
Adds complete StoreKit 2 integration for the Hibi Plus in-app purchase, enabling monetization of premium features (app icons, personalized stamp, home-screen widgets).

## Summary

This PR wires up the full purchase flow for Hibi Plus, a one-time non-consumable purchase that unlocks extra app icons, the personalized stamp feature, and home-screen widgets. The implementation uses StoreKit 2 for transaction verification and App Groups to sync entitlement state between the main app and widget extension.

## Key Changes

**Core Purchase Logic**
- `PlusStore`: New `@Observable` class that owns the StoreKit 2 purchase flow, listens for transaction updates, and reconciles entitlements. Syncs verified purchases to `PlusEntitlementStore` (App Group) so widgets can read the entitlement synchronously.
- `PlusEntitlementStore`: App-Group-backed mirror of the entitlement state, readable by both app and widget extension. Persists purchase date and a stable seed UUID.
- `PlusProduct`: Enum defining the product ID (`com.weichart.hibi.plus`).

**Stamp Personalization**
- Stamp design now seeded from the purchase UUID (StoreKit transaction's `appAccountToken`) rather than the date, ensuring identical rendering across launches.
- `StampConfig.seed(from:)` updated to hash UUIDs deterministically (FNV-1a) into a 24-bit range safe for Metal shaders.
- `HibiStamp` now accepts explicit `seed` parameter, decoupling design from displayed date.

**Widget Locking**
- `PlusLockOverlay`: New view modifier that renders a desaturated, dimmed widget with a centered lock chip and "Unlock widgets in the app" prompt.
- Both `EventsWidgetView` and `TodaysPageWidgetView` check `PlusEntitlementStore().isPlus` and apply the overlay when locked.
- Overlay clears automatically when `PlusStore` records the entitlement and reloads widget timelines.

**UI Updates**
- `PlusCTA` button now wires to real purchase flow: shows loading spinner during purchase, displays localized price from StoreKit, and handles success state.
- `RestorePurchasesLink` now calls `PlusStore.restore()` to sync App Store transactions.
- Price string parameterized in localizable strings (was hard-coded "$4.99").

**App Icon Gating**
- `AppIconManager.Unlock` enum extended with `.plus` case.
- Six premium icons (disco-balloon, leatherbag, pearl-hibi, etc.) now gated behind Plus entitlement.
- `AppIconManager.isPlus` property mirrors the entitlement so icon list re-renders on purchase.

**Testing & Configuration**
- `Hibi.storekit`: StoreKit configuration file defining the Plus product for local testing.
- Three new test suites: `AppIconUnlockTests`, `PlusEntitlementStoreTests`, `StampSeedTests` verify gating rules, persistence, and seed stability.
- `HibiTests` target added to the project.
- Debug row in Settings to toggle Plus state locally.

## Implementation Details

- Purchase UUID is bound at transaction time via `appAccountToken` and persists across restores/reinstalls, ensuring the stamp's design and dated text never change.
- For legacy purchases predating the UUID binding, a deterministic fallback UUID is derived from the transaction ID (splitmix64 fill).
- `PlusStore.start()` is idempotent and safe to call from `.task` on every view appearance; it reconciles StoreKit state and begins listening for transaction updates.
- Widget entitlement is read synchronously from App Group cache on every render, so the locked overlay clears the moment a purchase completes and timelines reload.
- All new strings localized across 11 languages (en, de, es, it, ja, ko, ms, pt-BR, zh-Hans-CN, zh-Hant-HK, zh-Hant-TW).

https://claude.ai/code/session_0153SSz1dzrFwpqtuXrf7b1U