### PR TITLE
Add stamp punch animation on Hibi Plus purchase

### DIFF
--- a/Hibi/Views/HibiPlusView.swift
+++ b/Hibi/Views/HibiPlusView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UIKit
 
 // MARK: - Layout constants
 
@@ -32,6 +33,7 @@ struct HibiStamp: View {
     @Environment(\.displayScale) private var displayScale
     @State private var pressScale: CGFloat = 1
     @State private var appeared = false
+    @State private var shouldAnimatePunch = false
 
     // Metal stamp state
     @State private var compositeImage: CGImage?
@@ -75,8 +77,25 @@ struct HibiStamp: View {
 
     private func runStampIn() {
         guard !appeared else { return }
-        appeared = true
-        pressScale = 1
+
+        if shouldAnimatePunch && !reduceMotion {
+            shouldAnimatePunch = false
+            withAnimation(.easeIn(duration: 0.18)) {
+                appeared = true
+                pressScale = 0.92
+            }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.18) {
+                let generator = UIImpactFeedbackGenerator(style: .heavy)
+                generator.impactOccurred()
+                withAnimation(.spring(response: 0.35, dampingFraction: 0.55)) {
+                    pressScale = 1.0
+                }
+            }
+        } else {
+            shouldAnimatePunch = false
+            appeared = true
+            pressScale = 1
+        }
     }
 
     private var sealBody: some View {
@@ -95,6 +114,8 @@ struct HibiStamp: View {
         .onChange(of: date) { _, _ in buildComposite() }
         .onChange(of: stampToken) { _, _ in
             appeared = false
+            shouldAnimatePunch = true
+            UIImpactFeedbackGenerator(style: .heavy).prepare()
             buildComposite()
         }
         .onReceive(NotificationCenter.default.publisher(for: .NSProcessInfoPowerStateDidChange)) { _ in


### PR DESCRIPTION
## Summary

- Adds a two-phase punch animation when the stamp appears after purchasing Hibi Plus: quick drop (easeIn 0.18s, scale 1.18→0.92) then spring settle (response 0.35, damping 0.55, back to 1.0)
- Fires a heavy haptic impact at the exact "landing" moment for tactile feedback, with `prepare()` called early to minimize latency
- Animation is gated by `shouldAnimatePunch` flag, which is only set when `stampToken` changes (purchase flow only) — normal app launches show the stamp instantly
- Respects Reduce Motion accessibility setting

## Test plan

- [ ] Purchase Hibi Plus (or trigger the purchase flow in sandbox) and verify the stamp animates in with a visible punch/settle effect
- [ ] Verify heavy haptic fires at the landing moment
- [ ] Relaunch the app — stamp should appear instantly without animation
- [ ] Enable Reduce Motion in Settings → Accessibility → Motion — stamp should appear instantly even during purchase
- [ ] Verify no regressions in the card flip transition leading into the stamp

🤖 Generated with [Claude Code](https://claude.com/claude-code)