### PR TITLE
Show spinner instead of placeholder price until StoreKit loads

### DIFF
--- a/Hibi/Localizable.xcstrings
+++ b/Hibi/Localizable.xcstrings
@@ -5726,6 +5726,78 @@
         }
       }
     },
+    "Loading price…": {
+      "comment": "Accessibility label on the purchase button while the StoreKit price is still loading.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preis wird geladen …"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Loading price…"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cargando precio…"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Caricamento prezzo…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "価格を読み込み中…"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "가격 불러오는 중…"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Memuatkan harga…"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Carregando preço…"
+          }
+        },
+        "zh-Hans-CN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在加载价格…"
+          }
+        },
+        "zh-Hant-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在載入價格…"
+          }
+        },
+        "zh-Hant-TW": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在載入價格…"
+          }
+        }
+      }
+    },
     "Local weather and sunrise / sunset on each day.": {
       "comment": "Onboarding row description for Location permission.",
       "extractionState": "manual",

--- a/Hibi/Models/PlusStore.swift
+++ b/Hibi/Models/PlusStore.swift
@@ -24,7 +24,8 @@ final class PlusStore {
     private(set) var isPurchasing = false
 
     /// Localized, ready-to-display price (e.g. "$4.99"). `nil` until the
-    /// product loads; views fall back to a hard-coded placeholder.
+    /// product loads; the purchase button shows a spinner while it's `nil`
+    /// rather than a placeholder, so a wrong-currency price is never shown.
     var displayPrice: String? { product?.displayPrice }
 
     private let entitlement: PlusEntitlementStore

--- a/Hibi/Models/PlusStore.swift
+++ b/Hibi/Models/PlusStore.swift
@@ -23,10 +23,22 @@ final class PlusStore {
     private(set) var product: Product?
     private(set) var isPurchasing = false
 
+    #if DEBUG
+    /// When set, `displayPrice` reports `nil` regardless of the loaded product,
+    /// so the purchase button's loading state can be exercised on demand
+    /// (products load instantly against the local `.storekit` config).
+    var debugSuppressPrice = false
+    #endif
+
     /// Localized, ready-to-display price (e.g. "$4.99"). `nil` until the
     /// product loads; the purchase button shows a spinner while it's `nil`
     /// rather than a placeholder, so a wrong-currency price is never shown.
-    var displayPrice: String? { product?.displayPrice }
+    var displayPrice: String? {
+        #if DEBUG
+        if debugSuppressPrice { return nil }
+        #endif
+        return product?.displayPrice
+    }
 
     private let entitlement: PlusEntitlementStore
     private var updatesTask: Task<Void, Never>?

--- a/Hibi/Views/HibiPlusView.swift
+++ b/Hibi/Views/HibiPlusView.swift
@@ -423,15 +423,19 @@ struct PlusCTA: View {
     var isPurchasing: Bool = false
     var isGenerating: Bool = false
     var isDone: Bool = false
-    /// Localized price, e.g. "$4.99". Falls back to the placeholder default.
-    var price: String = "$4.99"
+    /// Localized price, e.g. "$4.99". `nil` until StoreKit returns the product;
+    /// while `nil` the button shows a spinner and is disabled so a wrong-currency
+    /// placeholder is never shown.
+    var price: String?
     let onPurchase: () -> Void
 
     private var isBusy: Bool { isDone || isGenerating || isPurchasing }
+    /// Tappable only once a real price has loaded and no flow is in flight.
+    private var isReady: Bool { price != nil && !isBusy }
 
     var body: some View {
         Button {
-            guard !isBusy else { return }
+            guard isReady else { return }
             onPurchase()
         } label: {
             Group {
@@ -450,12 +454,7 @@ struct PlusCTA: View {
                         Text("Personalizing your Stamp…")
                             .font(.custom(AppFont.serifItalic, size: 13))
                     }
-                } else if isPurchasing {
-                    ProgressView()
-                        .tint(PaperTints.card1)
-                        .scaleEffect(0.9)
-                        .frame(height: 18)
-                } else {
+                } else if let price, !isPurchasing {
                     HStack(alignment: .firstTextBaseline, spacing: 8) {
                         Text(verbatim: price)
                             .font(.system(size: 15, weight: .medium, design: .monospaced))
@@ -463,6 +462,12 @@ struct PlusCTA: View {
                             .font(.custom(AppFont.serifItalic, size: 12.5))
                             .opacity(0.7)
                     }
+                } else {
+                    // Purchase in flight, or the price hasn't loaded yet.
+                    ProgressView()
+                        .tint(PaperTints.card1)
+                        .scaleEffect(0.9)
+                        .frame(height: 18)
                 }
             }
             .padding(.horizontal, 22)
@@ -473,12 +478,16 @@ struct PlusCTA: View {
             .shadow(color: Color(red: 0.16, green: 0.14, blue: 0.10).opacity(0.18), radius: 6, y: 2)
         }
         .buttonStyle(.plain)
-        .accessibilityLabel(
-            isDone ? Text("Done") :
-            isGenerating ? Text("Personalizing your Stamp") :
-            isPurchasing ? Text("Purchasing…") :
-            Text("Buy Hibi Plus, \(price) one-time")
-        )
+        .disabled(!isReady)
+        .accessibilityLabel(accessibilityLabel)
+    }
+
+    private var accessibilityLabel: Text {
+        if isDone { return Text("Done") }
+        if isGenerating { return Text("Personalizing your Stamp") }
+        if isPurchasing { return Text("Purchasing…") }
+        if let price { return Text("Buy Hibi Plus, \(price) one-time") }
+        return Text("Loading price…")
     }
 }
 
@@ -568,7 +577,7 @@ private struct FeatureCardBody: View {
     var isPurchasing: Bool = false
     var isGenerating: Bool = false
     var isDone: Bool = false
-    var price: String = "$4.99"
+    var price: String?
     let onPurchase: () -> Void
     let onRestore: () -> Void
     @AppStorage("useSimpleFont", store: AppGroup.defaults) private var useSimpleFont = false
@@ -928,7 +937,7 @@ struct HibiPlusView: View {
                             isPurchasing: isPurchasing,
                             isGenerating: isGeneratingStamp,
                             isDone: isDoneGenerating,
-                            price: plusStore.displayPrice ?? "$4.99",
+                            price: plusStore.displayPrice,
                             onPurchase: purchase,
                             onRestore: restore)
         }

--- a/Hibi/Views/HibiPlusView.swift
+++ b/Hibi/Views/HibiPlusView.swift
@@ -432,6 +432,9 @@ struct PlusCTA: View {
     private var isBusy: Bool { isDone || isGenerating || isPurchasing }
     /// Tappable only once a real price has loaded and no flow is in flight.
     private var isReady: Bool { price != nil && !isBusy }
+    /// Waiting on StoreKit for the price (no other flow in flight) — dim the
+    /// capsule so it reads as not-yet-interactive.
+    private var isLoadingPrice: Bool { price == nil && !isBusy }
 
     var body: some View {
         Button {
@@ -476,6 +479,7 @@ struct PlusCTA: View {
             .background(Color.primary)
             .clipShape(Capsule())
             .shadow(color: Color(red: 0.16, green: 0.14, blue: 0.10).opacity(0.18), radius: 6, y: 2)
+            .opacity(isLoadingPrice ? 0.5 : 1)
         }
         .buttonStyle(.plain)
         .disabled(!isReady)

--- a/Hibi/Views/SettingsView.swift
+++ b/Hibi/Views/SettingsView.swift
@@ -491,6 +491,18 @@ private struct PlusDebugRow: View {
         .tint(.black)
         .padding(.horizontal, 16)
         .padding(.vertical, 12)
+
+        Divider().padding(.leading, 16)
+
+        Toggle(isOn: Binding(
+            get: { plusStore.debugSuppressPrice },
+            set: { plusStore.debugSuppressPrice = $0 }
+        )) {
+            Label("Suppress Plus price", systemImage: "hourglass")
+        }
+        .tint(.black)
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
     }
 }
 #endif


### PR DESCRIPTION
The purchase CTA fell back to a hard-coded "$4.99" whenever the product
hadn't loaded (or failed to load), showing the wrong currency and amount
to non-US users. Thread the optional localized price through and render a
spinner with the button disabled until a real price arrives, so a
wrong-currency placeholder is never displayed.

https://claude.ai/code/session_01QRziYbByF2eQnXFtkaBqDY