### PR TITLE
Move day view swipe setting into new Behavior category

### DIFF
--- a/Hibi/Localizable.xcstrings
+++ b/Hibi/Localizable.xcstrings
@@ -1573,6 +1573,76 @@
         }
       }
     },
+    "Behavior": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verhalten"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Behavior"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Comportamiento"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Comportamento"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "動作"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "동작"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kelakuan"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Comportamento"
+          }
+        },
+        "zh-Hans-CN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "行为"
+          }
+        },
+        "zh-Hant-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "行為"
+          }
+        },
+        "zh-Hant-TW": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "行為"
+          }
+        }
+      }
+    },
     "Buy Hibi Plus, %@ one-time": {
       "extractionState": "manual",
       "localizations": {

--- a/Hibi/Views/SettingsView.swift
+++ b/Hibi/Views/SettingsView.swift
@@ -35,7 +35,7 @@ struct SettingsView: View {
     }
 
     enum SettingsDestination: String, Hashable, Identifiable {
-        case appearance, appIcon, units, calendars
+        case appearance, appIcon, behavior, units, calendars
         #if DEBUG
         case stampNoise
         #endif
@@ -81,6 +81,7 @@ struct SettingsView: View {
             switch destination {
             case .appearance: AppearanceSettingsView()
             case .appIcon: AppIconSettingsView()
+            case .behavior: BehaviorSettingsView()
             case .units: UnitsSettingsView()
             case .calendars: CalendarSelectionView()
             #if DEBUG
@@ -106,6 +107,9 @@ struct SettingsView: View {
                 settingsDivider
                 settingsNavRow("App Icon", systemImage: "app.dashed",
                                destination: .appIcon)
+                settingsDivider
+                settingsNavRow("Behavior", systemImage: "hand.draw",
+                               destination: .behavior)
                 settingsDivider
                 settingsNavRow("Units", systemImage: "ruler",
                                destination: .units)
@@ -306,7 +310,6 @@ struct SettingsView: View {
 
 private struct AppearanceSettingsView: View {
     @AppStorage("appearance") private var appearanceRaw: String = SettingsView.Appearance.system.rawValue
-    @AppStorage("invertDaySwipe") private var invertDaySwipe: Bool = false
     @AppStorage("preferCompactDayView") private var preferCompactDayView: Bool = false
     @AppStorage("useSimpleFont", store: AppGroup.defaults) private var useSimpleFont: Bool = false
 
@@ -325,13 +328,28 @@ private struct AppearanceSettingsView: View {
             }
 
             Section("Day View") {
-                Toggle("Invert swipe direction", isOn: $invertDaySwipe)
-                    .tint(.black)
                 Toggle("Prefer compact mode", isOn: $preferCompactDayView)
                     .tint(.black)
             }
         }
         .navigationTitle("Appearance")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}
+
+// MARK: - Behavior
+
+private struct BehaviorSettingsView: View {
+    @AppStorage("invertDaySwipe") private var invertDaySwipe: Bool = false
+
+    var body: some View {
+        Form {
+            Section("Day View") {
+                Toggle("Invert swipe direction", isOn: $invertDaySwipe)
+                    .tint(.black)
+            }
+        }
+        .navigationTitle("Behavior")
         .navigationBarTitleDisplayMode(.inline)
     }
 }


### PR DESCRIPTION
Promote the "Invert swipe direction" toggle out of Appearance into a
new top-level Behavior settings page, listed below App Icon. Keeps
"Prefer compact mode" under Appearance.

https://claude.ai/code/session_01TpuxnEa869btn8iAcbkn1j